### PR TITLE
Add matching RTD2/RTD3 three-panel heater plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey t
 I'll meet you over there, can't wait to get started!
 
 This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.
+
+## Running the slideshow locally
+
+If you want to preview your changes before pushing, use the built-in setup and server scripts:
+
+1. `script/setup` to install dependencies.
+2. `script/server` to start the local Jekyll server.
+3. Open `http://127.0.0.1:4000` in your browser.
+
+This is helpful when iterating on slide content in `_posts/` and layout changes in `_layouts/`.

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -60,10 +60,13 @@ def rate_limit(prev_cmd, cmd_target, slew_rate_w_per_s, dt):
 # USER SWITCHES
 # =============================================================================
 FIXED_DT = 0.01
-SUPERVISOR_ON = True
+SUPERVISOR_ON = False
 PRINT_EVERY = 20
 SP_FILTER_TAU = 1.5            # [s] setpoint prefilter time constant
 CMD_RATE_LIMIT_W_PER_S = 4.0   # [W/s] command slew-rate limit
+USE_ALLOCATOR = False          # baseline mode: keep PID authority
+USE_ANTICIPATORY_CUTOFF = False
+USE_HARD_CUTOFF = True
 OVERSHOOT_GUARD_HORIZON_S = 0.25  # [s] predictive cutoff horizon
 PREHEAT_HARD_CUTOFF_K = 0.5  # [K] force preheater OFF above filtered setpoint
 MAIN_HARD_CUTOFF_K = 0.5     # [K] force main heater OFF above filtered setpoint
@@ -337,6 +340,7 @@ class AdaptivePIDNN:
         adapt_rate_d=0.05,
         big_error_threshold=5.0,
         integral_clip=1e6,
+        u_max=1.0,
     ):
         self.kp0 = kp0
         self.ki0 = ki0
@@ -348,6 +352,7 @@ class AdaptivePIDNN:
         self.adapt_rate_i = adapt_rate_i
         self.adapt_rate_d = adapt_rate_d
         self.big_error_threshold = big_error_threshold
+        self.u_max = u_max
         self.integral = 0.0
         self.last_error = 0.0
         self.integral_clip = float(integral_clip)
@@ -355,32 +360,32 @@ class AdaptivePIDNN:
     def update(self, current_value, setpoint, dt):
         error = setpoint - current_value
 
-        # Leaky integrator reduces long-memory lock-in after large overshoot events.
-        self.integral *= 0.999
-        self.integral += error * dt
+        # Heating-only integration policy from the December script:
+        # accumulate when below setpoint, quickly decay when above.
+        if error > 0.0:
+            self.integral += error * dt
+        else:
+            self.integral *= max(0.0, 1.0 - 5.0 * dt)
         self.integral = float(np.clip(self.integral, -self.integral_clip, self.integral_clip))
 
         derivative = (error - self.last_error) / dt if dt > 0.0 else 0.0
         u = (self.kp * error) + (self.ki * self.integral) + (self.kd * derivative)
 
-        # Sign-consistent anti-windup: if control action fights the current error,
-        # bleed integral in the opposite direction and recompute u.
-        if error > 0.0 and u < 0.0:
-            self.integral = max(self.integral, 0.0)
-            u = (self.kp * error) + (self.ki * self.integral) + (self.kd * derivative)
-        elif error < 0.0 and u > 0.0:
-            self.integral = min(self.integral, 0.0)
-            u = (self.kp * error) + (self.ki * self.integral) + (self.kd * derivative)
+        # Heating actuator cannot command negative duty.
+        u = max(u, 0.0)
+        if self.u_max is not None:
+            u = min(u, self.u_max)
 
         abs_e = abs(error)
         abs_last_e = abs(self.last_error)
         big_err = self.big_error_threshold
 
-        if abs_e > big_err and abs_e >= abs_last_e:
+        if (error > 0.0) and (abs_e > big_err) and (abs_e >= abs_last_e):
             self.kp *= 1.0 + self.adapt_rate_p * dt
             self.ki *= 1.0 + self.adapt_rate_i * dt
 
-        if np.sign(error) != np.sign(self.last_error) and abs_last_e > big_err:
+        overshoot = (error < 0.0) and (abs_e > 0.5)
+        if overshoot and abs_last_e > big_err:
             self.kp *= 1.0 - self.adapt_rate_p * dt
             self.ki *= 1.0 - self.adapt_rate_i * dt
             self.kd *= 1.0 + self.adapt_rate_d * dt
@@ -587,8 +592,8 @@ def main():
     A_pre = A_ext * frac_pre
     A_main = A_ext * frac_main
 
-    pid2 = AdaptivePIDNN()
-    pid3 = AdaptivePIDNN()
+    pid2 = AdaptivePIDNN(u_max=1.0)
+    pid3 = AdaptivePIDNN(u_max=1.0)
 
     Ppre_applied = 0.0
     Pmain_applied = 0.0
@@ -741,34 +746,39 @@ def main():
         Ppre_cmd_next = d_pre_cmd_next * float(q_max)
         Pmain_cmd_next = d_main_cmd_next * float(q_max)
 
-        Ppre_cmd_next, Pmain_cmd_next = supervisor(Ppre_cmd_next, Pmain_cmd_next, e2, e3)
-        Ppre_cmd_next, Pmain_cmd_next = allocate_min_power(
-            Ppre_cmd_next,
-            Pmain_cmd_next,
-            e2,
-            e3,
-            losses_pre,
-            losses_main,
-            deadband_K=deadband,
-        )
+        if SUPERVISOR_ON:
+            Ppre_cmd_next, Pmain_cmd_next = supervisor(Ppre_cmd_next, Pmain_cmd_next, e2, e3)
 
-        Ppre_cmd_next, Pmain_cmd_next = apply_anticipatory_cutoff(
-            Ppre_cmd_next,
-            Pmain_cmd_next,
-            T2,
-            T3,
-            SP2_f,
-            SP3_f,
-            dT2_dt,
-            dT3_dt,
-            OVERSHOOT_GUARD_HORIZON_S,
-        )
+        if USE_ALLOCATOR:
+            Ppre_cmd_next, Pmain_cmd_next = allocate_min_power(
+                Ppre_cmd_next,
+                Pmain_cmd_next,
+                e2,
+                e3,
+                losses_pre,
+                losses_main,
+                deadband_K=deadband,
+            )
 
-        # Hard thermal safety cutoff: never keep heating when node is above filtered target.
-        if T2 >= (SP2_f + PREHEAT_HARD_CUTOFF_K):
-            Ppre_cmd_next = 0.0
-        if T3 >= (SP3_f + MAIN_HARD_CUTOFF_K):
-            Pmain_cmd_next = 0.0
+        if USE_ANTICIPATORY_CUTOFF:
+            Ppre_cmd_next, Pmain_cmd_next = apply_anticipatory_cutoff(
+                Ppre_cmd_next,
+                Pmain_cmd_next,
+                T2,
+                T3,
+                SP2_f,
+                SP3_f,
+                dT2_dt,
+                dT3_dt,
+                OVERSHOOT_GUARD_HORIZON_S,
+            )
+
+        if USE_HARD_CUTOFF:
+            # Hard thermal safety cutoff: never keep heating when node is above filtered target.
+            if T2 >= (SP2_f + PREHEAT_HARD_CUTOFF_K):
+                Ppre_cmd_next = 0.0
+            if T3 >= (SP3_f + MAIN_HARD_CUTOFF_K):
+                Pmain_cmd_next = 0.0
 
         Ppre_cmd_next = rate_limit(Ppre_cmd_prev, Ppre_cmd_next, CMD_RATE_LIMIT_W_PER_S, FIXED_DT)
         Pmain_cmd_next = rate_limit(Pmain_cmd_prev, Pmain_cmd_next, CMD_RATE_LIMIT_W_PER_S, FIXED_DT)

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -73,6 +73,10 @@ OVERSHOOT_GUARD_HORIZON_S = 0.25  # [s] predictive cutoff horizon
 NOZZLE_DIAGNOSTICS_EVERY = 10  # compute expensive nozzle metrics every N steps (1 = every step)
 PREHEAT_HARD_CUTOFF_K = 0.5  # [K] force preheater OFF above filtered setpoint
 MAIN_HARD_CUTOFF_K = 0.5     # [K] force main heater OFF above filtered setpoint
+# Wall-temperature stabilization guards
+MIN_HC_W_M2K = 250.0          # lower bound for internal h to avoid q''/h blow-ups
+MAX_QFLUX_W_M2 = 2.0e6        # cap local imposed heat flux for wall diagnostic stability
+MAX_WALL_SUPERHEAT_K = 120.0  # cap (T_wall - T_fluid) diagnostic rise
 
 # =============================================================================
 # DISCRETIZATION / RUNTIME
@@ -548,7 +552,8 @@ def plant_step_transient(
         p_new[i] = float(max(p_new[i - 1] - dp, 1e3))
 
         Nu = 4.96
-        hc = Nu * k_mix / (Dh[i] + EPS)
+        hc_raw = Nu * k_mix / (Dh[i] + EPS)
+        hc_eff = max(hc_raw, MIN_HC_W_M2K)
 
         if i < rtd2:
             qflux = Q[i] / (Perim[i] * dx + EPS)
@@ -556,11 +561,14 @@ def plant_step_transient(
             qflux = Q[i] / (W_int[i] * dx + EPS)
         else:
             qflux = 0.0
+        qflux = float(np.clip(qflux, 0.0, MAX_QFLUX_W_M2))
 
         T_new = robust_temperature_from_ph(p_new[i], h_new[i], specie)
 
         T_fl[i] = float(T_new)
-        T_w[i] = qflux / (hc + EPS) + float(T_new)
+        dT_wall = qflux / (hc_eff + EPS)
+        dT_wall = float(np.clip(dT_wall, 0.0, MAX_WALL_SUPERHEAT_K))
+        T_w[i] = float(T_new) + dT_wall
 
     T_fl[0] = T_inlet
     T_w[0] = T_inlet

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -318,7 +318,8 @@ def zone_losses(Tw_zone, A_zone):
 
 def estimate_representative_velocity(h, p, A_cs, mass_flow, specie):
     """Estimate representative channel velocity for adaptive-CFL dt selection."""
-    vmax = 0.0
+    v_sum = 0.0
+    n_pts = 0
     for i in range(1, len(h)):
         p_i = float(max(p[i], 1e3))
         h_i = float(h[i])
@@ -330,9 +331,9 @@ def estimate_representative_velocity(h, p, A_cs, mass_flow, specie):
             h_eval = float(np.clip(h_i, hL - 8e4, hV + 8e4))
             rho_i = float(CP.PropsSI("D", "P", p_i, "H", h_eval, specie))
         v_i = mass_flow / (max(rho_i, EPS) * max(float(A_cs[i]), EPS))
-        if v_i > vmax:
-            vmax = v_i
-    return float(max(vmax, EPS))
+        v_sum += v_i
+        n_pts += 1
+    return float(max(v_sum / max(n_pts, 1), EPS))
 
 
 def robust_temperature_from_ph(p_val, h_val, specie):
@@ -633,6 +634,13 @@ def plant_step_transient(
     pre_available = max(P_pre_net, 0.0) + max(Cw_pre, EPS) * max(Tw_pre_zone - Tref_pre, 0.0) / max(dt_fixed, EPS)
     main_available = max(P_main_net, 0.0) + max(Cw_main, EPS) * max(Tw_main_zone - Tref_main, 0.0) / max(dt_fixed, EPS)
 
+    Qdot_f_pre_sum_raw = float(Qdot_f_pre_sum)
+    Qdot_f_main_sum_raw = float(Qdot_f_main_sum)
+    scale_pre = float(min(1.0, pre_available / (Qdot_f_pre_sum_raw + 1e-12)))
+    scale_main = float(min(1.0, main_available / (Qdot_f_main_sum_raw + 1e-12)))
+    Qdot_f_pre_sum = Qdot_f_pre_sum_raw * scale_pre
+    Qdot_f_main_sum = Qdot_f_main_sum_raw * scale_main
+
     Tw_pre_next = float(Tw_pre_zone + dt_fixed * (max(P_pre_net, 0.0) - Qdot_f_pre_sum) / max(Cw_pre, EPS))
     Tw_main_next = float(Tw_main_zone + dt_fixed * (max(P_main_net, 0.0) - Qdot_f_main_sum) / max(Cw_main, EPS))
 
@@ -642,8 +650,12 @@ def plant_step_transient(
     conv_diag = {
         "pre_qconv": float(Qdot_f_pre_sum),
         "main_qconv": float(Qdot_f_main_sum),
+        "pre_qconv_raw": float(Qdot_f_pre_sum_raw),
+        "main_qconv_raw": float(Qdot_f_main_sum_raw),
         "pre_qavail": float(pre_available),
         "main_qavail": float(main_available),
+        "pre_scale": float(scale_pre),
+        "main_scale": float(scale_main),
     }
 
     return h_new, p_new, T_fl, T_w, Tw_pre_next, Tw_main_next, conv_diag
@@ -840,8 +852,8 @@ def main():
         losses_pre = losses_pre_now
         losses_main = losses_main_now
 
-        conv_overdraw_pre_hist[k] = max(0.0, conv_diag["pre_qconv"] - conv_diag["pre_qavail"])
-        conv_overdraw_main_hist[k] = max(0.0, conv_diag["main_qconv"] - conv_diag["main_qavail"])
+        conv_overdraw_pre_hist[k] = max(0.0, conv_diag["pre_qconv_raw"] - conv_diag["pre_qavail"])
+        conv_overdraw_main_hist[k] = max(0.0, conv_diag["main_qconv_raw"] - conv_diag["main_qavail"])
 
         if e2 > deadband:
             d_pre_cmd_next = float(np.clip(u2, 0.0, 1.0))

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -190,6 +190,8 @@ def nozzle_metrics(T0, P0, x_vap, specie="Water"):
 
 q_max = 20.0
 deadband = 1.0
+POWER_SPLIT_PRE = 0.5
+POWER_SPLIT_MAIN = 0.5
 
 
 # =============================================================================
@@ -647,6 +649,12 @@ def main():
         Pmain_cmd_next = d_main_cmd_next * float(q_max)
 
         Ppre_cmd_next, Pmain_cmd_next = supervisor(Ppre_cmd_next, Pmain_cmd_next, e2, e3)
+
+        # Enforce fixed total-power split between preheater and main heater.
+        # This applies your requested 50/50 split policy.
+        P_total_cmd_next = Ppre_cmd_next + Pmain_cmd_next
+        Ppre_cmd_next = POWER_SPLIT_PRE * P_total_cmd_next
+        Pmain_cmd_next = POWER_SPLIT_MAIN * P_total_cmd_next
 
         Ppre_applied_hist[k] = Ppre_applied
         Pmain_applied_hist[k] = Pmain_applied

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -43,12 +43,24 @@ def pwm_gate(t, duty, period):
     return 1.0 if phase < duty else 0.0
 
 
+def low_pass_setpoint(prev_sp, target_sp, dt, tau_s):
+    alpha = float(np.clip(dt / max(tau_s, 1e-6), 0.0, 1.0))
+    return prev_sp + alpha * (target_sp - prev_sp)
+
+
+def rate_limit(prev_cmd, cmd_target, slew_rate_w_per_s, dt):
+    delta_max = max(slew_rate_w_per_s, 0.0) * max(dt, 0.0)
+    return float(np.clip(cmd_target, prev_cmd - delta_max, prev_cmd + delta_max))
+
+
 # =============================================================================
 # USER SWITCHES
 # =============================================================================
 FIXED_DT = 0.01
 SUPERVISOR_ON = True
 PRINT_EVERY = 20
+SP_FILTER_TAU = 1.5            # [s] setpoint prefilter time constant
+CMD_RATE_LIMIT_W_PER_S = 4.0   # [W/s] command slew-rate limit
 
 # =============================================================================
 # DISCRETIZATION / RUNTIME
@@ -374,31 +386,31 @@ def supervisor(Ppre_cmd, Pmain_cmd, e2, e3, deadband_K=1.0, scale_min=0.3):
 
 
 def allocate_min_power(Ppre_cmd, Pmain_cmd, e2, e3, losses_pre, losses_main, deadband_K=1.0):
-    """Energy-aware allocator.
+    """Energy-aware allocator with anti-lockout behavior.
 
-    - Prioritize main-heater power for RTD3 tracking.
-    - Disable preheater unless both sections are cold and RTD3 still needs heat.
-    - In the near-setpoint region, only apply loss-compensation power.
-    - Enforce minimum RTD3 recovery power when RTD3 is far below setpoint.
+    - Main heater owns RTD3 tracking.
+    - During RTD3 overshoot, main heater is forced OFF, while preheater may still
+      provide limited recovery when RTD2 is below target.
+    - Near setpoint, commands collapse to estimated loss-compensation levels.
     """
-    # Any RTD3 overshoot: stop active heating to avoid oscillatory re-heating.
-    if e3 < -deadband_K:
-        return 0.0, 0.0
-
     Ppre = max(Ppre_cmd, 0.0)
     Pmain = max(Pmain_cmd, 0.0)
 
-    # Near setpoint: only hold estimated thermal losses.
+    # Near both setpoints -> hold only loss compensation.
     if abs(e3) <= 2.0 * deadband_K and abs(e2) <= 2.0 * deadband_K:
         return float(np.clip(losses_pre, 0.0, q_max)), float(np.clip(losses_main, 0.0, q_max))
 
-    # Guarantee a non-zero recovery action for RTD3 when far below target,
-    # even if PID raw output briefly goes negative due to integral history.
+    # RTD3 overshoot: shut main heater down but allow mild RTD2 recovery if needed.
+    if e3 < -deadband_K:
+        pre_recovery = max(Ppre, losses_pre) if e2 > deadband_K else 0.0
+        return float(np.clip(pre_recovery, 0.0, q_max)), 0.0
+
+    # RTD3 undershoot: enforce non-zero main recovery action.
     if e3 > 3.0 * deadband_K:
         min_recovery = max(0.10 * q_max, losses_main)
         Pmain = max(Pmain, min_recovery)
 
-    # RTD3 gets primary authority; preheater acts only as assist when both are cold.
+    # Preheater assists only when both zones are below target.
     if not (e3 > 2.0 * deadband_K and e2 > deadband_K):
         Ppre = 0.0
 
@@ -568,6 +580,8 @@ def main():
     Tw3_hist = np.zeros(n_steps)
     SP2_hist = np.zeros(n_steps)
     SP3_hist = np.zeros(n_steps)
+    SP2_f_hist = np.zeros(n_steps)
+    SP3_f_hist = np.zeros(n_steps)
 
     u2_raw = np.zeros(n_steps)
     u3_raw = np.zeros(n_steps)
@@ -590,6 +604,11 @@ def main():
     noz_mdot_act = np.zeros(n_steps)
     noz_ue = np.zeros(n_steps)
     noz_eta_u = np.zeros(n_steps)
+
+    SP2_f = float(setpoint_rtd2(0.0))
+    SP3_f = float(setpoint_rtd3(0.0))
+    Ppre_cmd_prev = 0.0
+    Pmain_cmd_prev = 0.0
 
     for k in tqdm(range(1, n_steps), desc="Simulating", dynamic_ncols=True):
         t = k * FIXED_DT
@@ -643,14 +662,18 @@ def main():
 
         SP2 = float(setpoint_rtd2(t))
         SP3 = float(setpoint_rtd3(t))
+        SP2_f = low_pass_setpoint(SP2_f, SP2, FIXED_DT, SP_FILTER_TAU)
+        SP3_f = low_pass_setpoint(SP3_f, SP3, FIXED_DT, SP_FILTER_TAU)
         SP2_hist[k] = SP2
         SP3_hist[k] = SP3
+        SP2_f_hist[k] = SP2_f
+        SP3_f_hist[k] = SP3_f
 
-        e2 = SP2 - T2
-        e3 = SP3 - T3
+        e2 = SP2_f - T2
+        e3 = SP3_f - T3
 
-        u2 = float(pid2.update(T2, SP2, FIXED_DT))
-        u3 = float(pid3.update(T3, SP3, FIXED_DT))
+        u2 = float(pid2.update(T2, SP2_f, FIXED_DT))
+        u3 = float(pid3.update(T3, SP3_f, FIXED_DT))
         u2_raw[k] = u2
         u3_raw[k] = u3
 
@@ -700,6 +723,11 @@ def main():
             losses_main,
             deadband_K=deadband,
         )
+
+        Ppre_cmd_next = rate_limit(Ppre_cmd_prev, Ppre_cmd_next, CMD_RATE_LIMIT_W_PER_S, FIXED_DT)
+        Pmain_cmd_next = rate_limit(Pmain_cmd_prev, Pmain_cmd_next, CMD_RATE_LIMIT_W_PER_S, FIXED_DT)
+        Ppre_cmd_prev = Ppre_cmd_next
+        Pmain_cmd_prev = Pmain_cmd_next
 
         Ppre_applied_hist[k] = Ppre_applied
         Pmain_applied_hist[k] = Pmain_applied
@@ -771,8 +799,8 @@ def main():
 
         fig.tight_layout()
 
-    plot_heater_panel("RTD2", T2_hist, Tw2_hist, SP2_hist, Ppre_applied_hist, kp2_hist, ki2_hist, kd2_hist)
-    plot_heater_panel("RTD3", T3_hist, Tw3_hist, SP3_hist, Pmain_applied_hist, kp3_hist, ki3_hist, kd3_hist)
+    plot_heater_panel("RTD2", T2_hist, Tw2_hist, SP2_f_hist, Ppre_applied_hist, kp2_hist, ki2_hist, kd2_hist)
+    plot_heater_panel("RTD3", T3_hist, Tw3_hist, SP3_f_hist, Pmain_applied_hist, kp3_hist, ki3_hist, kd3_hist)
 
     plt.figure(figsize=(14, 10))
 

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -81,11 +81,13 @@ MAX_QFLUX_W_M2 = 2.0e6        # cap local imposed heat flux for wall diagnostic 
 MAX_WALL_SUPERHEAT_K = 120.0  # cap (T_wall - T_fluid) diagnostic rise
 WALL_CAP_PRE_J_PER_K = 0.02
 WALL_CAP_MAIN_J_PER_K = 0.03
-# Minimal dryout/regime model (placeholder until CHF correlation is added)
+# CHF / dryout correlation controls
 NU_BASE = 4.96
-X_DRYOUT_ONSET = 0.85
 NU_POST_DRYOUT_MIN = 1.2
-DRYOUT_NU_DROP_MAX = 0.7
+XDO_MIN = 0.55
+XDO_MAX = 0.98
+CHF_C0 = 0.131  # Kutateladze-style prefactor
+CHF_SAFETY_FACTOR = 0.90
 
 # Paper-style neural adaptive PID constraints
 KP_MAX_PAPER = 0.001
@@ -169,6 +171,48 @@ def quality_from_hP(h_val, p_val, specie="Water", clip=True):
     if clip:
         x = np.clip(x, 0.0, 1.0)
     return float(x)
+
+
+def compute_chf_dryout_state(x_loc, G, Dh_i, rho_l, rho_v, mu_l, h_fg, sigma, q_flux_dem):
+    """Correlation-based dryout/CHF model for microchannel two-phase flow.
+
+    Returns:
+        x_do: dryout-onset quality from combined correlations
+        q_chf: local CHF estimate [W/m^2]
+        q_flux_lim: capped convective heat flux [W/m^2]
+        Nu_eff_scale: multiplicative factor applied to nominal Nu
+        regime: string label
+    """
+    # Dimensionless groups
+    Bo = float(np.clip(q_flux_dem / (max(G, EPS) * max(h_fg, EPS)), 1e-8, 1.0))
+    We_lo = float(np.clip((G**2) * max(Dh_i, EPS) / (max(rho_l, EPS) * max(sigma, EPS)), 1e-8, 1e8))
+    La = float(np.clip(max(sigma, EPS) * max(rho_l - rho_v, EPS) * max(Dh_i, EPS) / (max(rho_v, EPS) * (max(mu_l, EPS)**2)), 1e-6, 1e10))
+
+    # Dryout-onset quality correlations (bounded, blended by minimum for conservative prediction)
+    x_incip = float(np.clip(0.99 - 2.25 * (Bo ** 0.35), XDO_MIN, XDO_MAX))
+    x_crit = float(np.clip(0.88 - 0.08 * (We_lo ** -0.10), XDO_MIN, XDO_MAX))
+    x_dry_max = float(np.clip(0.96 - 0.04 * (La ** -0.05), XDO_MIN, XDO_MAX))
+    x_do = float(np.clip(min(x_incip, x_crit, x_dry_max), XDO_MIN, XDO_MAX))
+
+    # Kutateladze-like CHF estimate with two-phase velocity boost
+    q_chf = CHF_C0 * h_fg * math.sqrt(max(rho_v, EPS)) * (max(sigma, EPS) * g0 * max(rho_l - rho_v, EPS)) ** 0.25
+    two_phase_boost = float(np.clip((1.0 + 2.0 * We_lo ** 0.20), 1.0, 6.0))
+    q_chf *= two_phase_boost * CHF_SAFETY_FACTOR
+
+    if not (0.0 < x_loc < 1.0):
+        return x_do, q_chf, q_flux_dem, 1.0, "single_phase"
+
+    if x_loc < x_do:
+        q_flux_lim = min(q_flux_dem, q_chf)
+        return x_do, q_chf, q_flux_lim, 1.0, "nucleate_boiling"
+
+    # Post-dryout: degrade transfer with quality and CHF exceedance
+    dryout_frac = float(np.clip((x_loc - x_do) / max(1.0 - x_do, EPS), 0.0, 1.0))
+    chf_ratio = float(np.clip(q_flux_dem / max(q_chf, EPS), 0.0, 5.0))
+    nu_scale = float(np.clip((1.0 - 0.80 * dryout_frac) * (1.0 / (1.0 + 0.35 * max(chf_ratio - 1.0, 0.0))),
+                             NU_POST_DRYOUT_MIN / max(NU_BASE, EPS), 1.0))
+    q_flux_lim = min(q_flux_dem, q_chf)
+    return x_do, q_chf, q_flux_lim, nu_scale, "post_dryout"
 
 
 def nozzle_metrics(T0, P0, x_vap, specie="Water"):
@@ -555,6 +599,8 @@ def plant_step_transient(
 
     Qdot_f_pre_sum = 0.0
     Qdot_f_main_sum = 0.0
+    chf_limited_cells = 0
+    post_dryout_cells = 0
 
     for i in range(1, n):
         p_i = float(max(p[i], 1e3))
@@ -594,14 +640,27 @@ def plant_step_transient(
         p_new[i] = float(max(p_new[i - 1] - dp, 1e3))
 
         x_loc = float(np.clip(quality_from_hP(h_eval, p_i, specie, clip=False), 0.0, 1.0))
-        if 0.0 < x_loc < 1.0 and x_loc >= X_DRYOUT_ONSET:
-            dryout_frac = (x_loc - X_DRYOUT_ONSET) / max(1.0 - X_DRYOUT_ONSET, EPS)
-            dryout_frac = float(np.clip(dryout_frac, 0.0, 1.0))
-            Nu_eff = NU_BASE * (1.0 - DRYOUT_NU_DROP_MAX * dryout_frac)
-            Nu_eff = float(max(NU_POST_DRYOUT_MIN, Nu_eff))
-        else:
-            Nu_eff = NU_BASE
+        rhoL_loc = CP.PropsSI("D", "P", p_i, "Q", 0, specie)
+        rhoV_loc = CP.PropsSI("D", "P", p_i, "Q", 1, specie)
+        hfg_loc = CP.PropsSI("H", "P", p_i, "Q", 1, specie) - CP.PropsSI("H", "P", p_i, "Q", 0, specie)
+        sigma_loc = CP.PropsSI("I", "P", p_i, "Q", 0, specie)
+        G_loc = mass_flow / (A_flow + EPS)
 
+        hb_nom = NU_BASE * k_mix / (Dh[i] + EPS)
+
+        q_flux_dem = max(0.0, hb_nom * (float((Tw_pre_zone if i < rtd2 else Tw_main_zone) if i < rtd3 else T_i) - float(T_i)))
+        x_do, q_chf, q_flux_lim, nu_scale, regime = compute_chf_dryout_state(
+            x_loc=x_loc,
+            G=G_loc,
+            Dh_i=float(Dh[i]),
+            rho_l=float(rhoL_loc),
+            rho_v=float(rhoV_loc),
+            mu_l=float(muL),
+            h_fg=float(max(hfg_loc, EPS)),
+            sigma=float(max(sigma_loc, EPS)),
+            q_flux_dem=float(q_flux_dem),
+        )
+        Nu_eff = max(NU_POST_DRYOUT_MIN, NU_BASE * nu_scale)
         hb = Nu_eff * k_mix / (Dh[i] + EPS)
 
         if i < rtd2:
@@ -615,7 +674,14 @@ def plant_step_transient(
             zone = "none"
 
         A_ex_i = float(Perim[i] * dx)
-        Qdot_f_i = max(0.0, hb * (Tw_loc - float(T_i)) * A_ex_i)
+        Qdot_nom_i = max(0.0, hb * (Tw_loc - float(T_i)) * A_ex_i)
+        Qdot_chf_cap_i = max(0.0, q_chf * A_ex_i)
+        Qdot_f_i = min(Qdot_nom_i, Qdot_chf_cap_i)
+
+        if regime == "post_dryout":
+            post_dryout_cells += 1
+        if Qdot_f_i + 1e-12 < Qdot_nom_i:
+            chf_limited_cells += 1
 
         if zone == "pre":
             Qdot_f_pre_sum += Qdot_f_i
@@ -654,6 +720,8 @@ def plant_step_transient(
         "main_qconv": float(Qdot_f_main_sum),
         "pre_qavail": float(pre_available),
         "main_qavail": float(main_available),
+        "chf_limited_cells": int(chf_limited_cells),
+        "post_dryout_cells": int(post_dryout_cells),
     }
 
     return h_new, p_new, T_fl, T_w, Tw_pre_next, Tw_main_next, conv_diag
@@ -738,6 +806,8 @@ def main():
     dt_hist = np.zeros(n_steps)
     conv_overdraw_pre_hist = np.zeros(n_steps)
     conv_overdraw_main_hist = np.zeros(n_steps)
+    chf_limited_cells_hist = np.zeros(n_steps)
+    post_dryout_cells_hist = np.zeros(n_steps)
 
     SP2_f = float(setpoint_rtd2(0.0))
     SP3_f = float(setpoint_rtd3(0.0))
@@ -852,6 +922,8 @@ def main():
 
         conv_overdraw_pre_hist[k] = max(0.0, conv_diag["pre_qconv"] - conv_diag["pre_qavail"])
         conv_overdraw_main_hist[k] = max(0.0, conv_diag["main_qconv"] - conv_diag["main_qavail"])
+        chf_limited_cells_hist[k] = conv_diag["chf_limited_cells"]
+        post_dryout_cells_hist[k] = conv_diag["post_dryout_cells"]
 
         if e2 > deadband:
             d_pre_cmd_next = float(np.clip(u2, 0.0, 1.0))

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -1,0 +1,776 @@
+# -*- coding: utf-8 -*-
+"""
+Two-heater, dual adaptive PID (December logic), FIXED dt=0.01 s.
+ZOH timing: commands computed at k are applied at k+1 (NO RTD2->RTD3 within same step).
+
+Fixes applied:
+- EPS moved before first use (prevents NameError in nozzle functions).
+- RAW PID traces are labeled as duty (not Watts) to match actuator logic.
+- More explicit CoolProp phase handling for non-liquid/gas regions.
+"""
+
+import math
+
+import CoolProp.CoolProp as CP
+import matplotlib.pyplot as plt
+import numpy as np
+from tqdm import tqdm
+
+# =============================================================================
+# GLOBAL NUMERICAL SAFETY
+# =============================================================================
+EPS = 1e-30  # tiny number to prevent division-by-zero
+
+# =========================
+# PWM / Duty-cycle actuation (paper-like power spikes)
+# =========================
+PWM_ON = True
+PWM_PERIOD = 0.50
+P_MAX_PRE = None
+P_MAX_MAIN = None
+
+
+def _clip01(x):
+    return 0.0 if x < 0.0 else (1.0 if x > 1.0 else float(x))
+
+
+def duty_from_power(P_cmd, P_max):
+    return _clip01(P_cmd / (P_max + EPS))
+
+
+def pwm_gate(t, duty, period):
+    phase = (t % period) / period
+    return 1.0 if phase < duty else 0.0
+
+
+# =============================================================================
+# USER SWITCHES
+# =============================================================================
+FIXED_DT = 0.01
+SUPERVISOR_ON = True
+PRINT_EVERY = 20
+
+# =============================================================================
+# DISCRETIZATION / RUNTIME
+# =============================================================================
+n_it = 200
+n_steps = 5000
+
+# =============================================================================
+# GEOMETRY (December)
+# =============================================================================
+H_int = 160e-6
+
+L_inlet = 1200e-6
+W_inlet = 500e-6
+
+channelWidth = 120e-6
+channelNum = 3
+finWidth = 70e-6
+finNum = 2
+L_uCh = 6200e-6
+
+L_intDiv = 2200e-6
+W_intDiv1 = channelNum * channelWidth + finNum * finWidth
+W_intDiv2 = 3000e-6
+alpha_intDiv1 = math.degrees(math.atan(0.5 * (W_intDiv2 - W_intDiv1) / L_intDiv))
+
+L_int = 17160e-6
+dx = L_int / n_it
+
+L_ext = 19900e-6
+W_ext = 5000e-6
+H_ext = 500e-6
+A_ext = L_ext * W_ext * 2 + H_ext * L_ext * 2 + H_ext * W_ext * 2
+
+# =============================================================================
+# CONSTANTS / OPERATING POINT
+# =============================================================================
+specie = "Water"
+T_ambient = 298.0
+h_conv_ext = 100.0
+sigma_stef_boltz = 5.670373e-8
+k_Si = 149.0
+em = 0.05
+
+T_wall_start = 150 + 273.15
+T_fl_start = 298.0
+
+p_start = 370000.0
+mass_flow = 1.90e-6
+
+# =============================================================================
+# NOZZLE MODEL
+# =============================================================================
+p_ambient = 101325.0
+g0 = 9.81
+
+W_t = 70e-6
+W_e = 300e-6
+A_t = W_t * H_int
+A_e = W_e * H_int
+throatCurv = 35e-6
+div_length = 1200e-6
+
+
+def quality_from_hP(h_val, p_val, specie="Water", clip=True):
+    p_use = float(max(p_val, 1e3))
+    hL = CP.PropsSI("H", "P", p_use, "Q", 0, specie)
+    hV = CP.PropsSI("H", "P", p_use, "Q", 1, specie)
+    denom = hV - hL
+    if abs(denom) < 1e-12:
+        return 0.0
+    x = (h_val - hL) / denom
+    if clip:
+        x = np.clip(x, 0.0, 1.0)
+    return float(x)
+
+
+def nozzle_metrics(T0, P0, x_vap, specie="Water"):
+    if P0 <= p_ambient * 1.001:
+        return 0.0, 0.0, 0.0
+
+    T_sat = CP.PropsSI("T", "P", P0, "Q", 0, specie)
+
+    cp_L = CP.PropsSI("Cpmass", "T", T_sat, "Q", 0, specie)
+    cv_L = CP.PropsSI("Cvmass", "T", T_sat, "Q", 0, specie)
+    cp_V = CP.PropsSI("Cpmass", "T", T_sat, "Q", 1, specie)
+    cv_V = CP.PropsSI("Cvmass", "T", T_sat, "Q", 1, specie)
+
+    cp = (1.0 - x_vap) * cp_L + x_vap * cp_V
+    cv = (1.0 - x_vap) * cv_L + x_vap * cv_V
+    gamma = float(cp / (cv + EPS))
+    Rs = float(cp - cv)
+
+    T_star = T0 * 2.0 / (gamma + 1.0)
+    P_star = P0 * (T_star / T0) ** (gamma / (gamma - 1.0))
+    rho_star = P_star / (Rs * T_star + EPS)
+    a_star = math.sqrt(gamma * Rs * T_star)
+    m_dot_ideal = rho_star * a_star * A_t
+
+    mu_L = CP.PropsSI("V", "T", T_sat, "Q", 0, specie)
+    mu_V = CP.PropsSI("V", "T", T_sat, "Q", 1, specie)
+    mu_mix = (1.0 - x_vap) * mu_L + x_vap * mu_V
+    mu_star = mu_mix * (T_star / T_sat) ** 0.7
+
+    Re_star = rho_star * a_star * W_t / (mu_star + 1e-8)
+
+    rc = throatCurv
+    f_gamma = 0.97 + 0.86 * gamma
+    base1 = (rc + 0.05 * 0.5 * W_t) / (rc + 0.75 * 0.5 * W_t + EPS)
+    base2 = (rc + 0.10 * 0.5 * W_t) / (0.5 * W_t + EPS)
+    Cd_noz = base1 ** 0.019 * (1.0 - base2 ** 0.21 * Re_star ** -0.5 * f_gamma)
+    Cd_noz = float(np.clip(Cd_noz, 0.0, 1.0))
+
+    m_dot_act = Cd_noz * m_dot_ideal
+
+    M_e_sq = ((P0 / p_ambient) ** ((gamma - 1.0) / gamma) - 1.0) * 2.0 / (gamma - 1.0)
+    M_e = math.sqrt(max(M_e_sq, 0.0))
+    T_e = T0 / (1.0 + 0.5 * (gamma - 1.0) * M_e**2)
+    a_e = math.sqrt(gamma * Rs * T_e)
+    u_e = M_e * a_e
+
+    rho_e = p_ambient / (Rs * T_e + EPS)
+    mu_e = mu_star * (T_e / T_star) ** 0.7
+    Re_e = rho_e * u_e * div_length / (mu_e + 1e-8)
+
+    delta_star_bar = 0.048 * div_length / (Re_e**0.2 + EPS)
+    theta_bar = 0.037 * div_length / (Re_e**0.2 + EPS)
+    S_bar = 0.048 / 0.037
+    S_delta = S_bar * (1.0 + 0.113 * M_e**2) + 0.290 * M_e**2
+    theta = theta_bar * (
+        1.0 - (0.92 * M_e**2 / (7.09 + M_e**2 + EPS)) * math.tanh(1.49 * (S_bar - 0.9))
+    )
+    delta_star = S_delta * theta
+    eta_u = 1.0 - (2.0 * delta_star / (W_e + EPS)) * (1.0 + theta / (delta_star + 1e-8))
+    eta_u = float(np.clip(eta_u, 0.0, 1.0))
+
+    return float(m_dot_act), float(u_e), float(eta_u)
+
+
+q_max = 20.0
+deadband = 1.0
+
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+def find_nearest_index(array, value):
+    return int(np.argmin(np.abs(array - value)))
+
+
+def calculate_parameters(
+    n_it,
+    L_int,
+    W_intDiv2,
+    alpha_intDiv1,
+    W_inlet,
+    L_inlet,
+    L_uCh,
+    L_intDiv,
+    channelNum,
+    channelWidth,
+    finNum,
+    finWidth,
+    H_int,
+):
+    dx_loc = L_int / n_it
+    x = np.arange(0, n_it * dx_loc, dx_loc)
+
+    dy_Div = dx_loc * np.tan(np.deg2rad(alpha_intDiv1))
+
+    W_int = np.zeros(len(x))
+    W_int[0] = W_inlet
+
+    for ii in range(1, len(x)):
+        if x[ii] < L_inlet:
+            W_int[ii] = W_inlet
+        elif (x[ii] >= L_inlet) and (x[ii] < (L_inlet + L_uCh)):
+            W_int[ii] = channelNum * channelWidth
+        elif (x[ii] >= (L_inlet + L_uCh)) and (x[ii] < (L_inlet + L_uCh + L_intDiv)):
+            W_int[ii] = W_int[ii - 1] + 2 * dy_Div
+        else:
+            W_int[ii] = W_intDiv2
+
+    for ii in range(len(x)):
+        if (x[ii] >= (L_inlet + L_uCh)) and (x[ii] < (L_inlet + L_uCh + L_intDiv)):
+            W_int[ii] += finNum * finWidth
+
+    A_cs = np.zeros(len(x))
+    Perim = np.zeros(len(x))
+    Dh = np.zeros(len(x))
+
+    for ii in range(len(x)):
+        if L_inlet <= x[ii] < (L_inlet + L_uCh):
+            A_cs[ii] = W_int[ii] * H_int
+            Perim[ii] = 2 * W_int[ii] + channelNum * H_int * 2
+            Dh[ii] = 4 * A_cs[ii] / (Perim[ii] + EPS)
+        else:
+            A_cs[ii] = W_int[ii] * H_int
+            Perim[ii] = 2 * W_int[ii] + H_int * 2
+            Dh[ii] = 4 * A_cs[ii] / (Perim[ii] + EPS)
+
+    return x, W_int, A_cs, Perim, Dh
+
+
+def calculation_P_cond_struct(k_mat, T_wall, T_amb, A_ext_local, L_ext_local):
+    return k_mat * (T_wall - T_amb) * A_ext_local / (L_ext_local + EPS)
+
+
+def calculation_P_rad(T_surf, T_amb, em, sigma_stef_boltz, A_ext_local):
+    return (T_surf**4 - T_amb**4) * em * sigma_stef_boltz * A_ext_local
+
+
+def calculation_P_conv(h_conv, T_wall, T_amb, A_ext_local):
+    return h_conv * A_ext_local * (T_wall - T_amb)
+
+
+# =============================================================================
+# SETPOINTS — Option B (stepwise)
+# =============================================================================
+def setpoint_rtd2(t):
+    if t < 10:
+        return 60 + 273.15
+    if t < 20:
+        return 80 + 273.15
+    if t < 30:
+        return 100 + 273.15
+    if t < 40:
+        return 110 + 273.15
+    return 120 + 273.15
+
+
+def setpoint_rtd3(t):
+    if t < 10:
+        return 60 + 273.15
+    if t < 20:
+        return 80 + 273.15
+    if t < 30:
+        return 100 + 273.15
+    if t < 40:
+        return 120 + 273.15
+    return 150 + 273.15
+
+
+# =============================================================================
+# ADAPTIVE PID
+# =============================================================================
+class AdaptivePIDNN:
+    def __init__(
+        self,
+        kp0=0.0005,
+        ki0=0.005,
+        kd0=0.0001,
+        adapt_rate_p=0.1,
+        adapt_rate_i=0.1,
+        adapt_rate_d=0.05,
+        big_error_threshold=5.0,
+        integral_clip=1e6,
+    ):
+        self.kp0 = kp0
+        self.ki0 = ki0
+        self.kd0 = kd0
+        self.kp = kp0
+        self.ki = ki0
+        self.kd = kd0
+        self.adapt_rate_p = adapt_rate_p
+        self.adapt_rate_i = adapt_rate_i
+        self.adapt_rate_d = adapt_rate_d
+        self.big_error_threshold = big_error_threshold
+        self.integral = 0.0
+        self.last_error = 0.0
+        self.integral_clip = float(integral_clip)
+
+    def update(self, current_value, setpoint, dt):
+        error = setpoint - current_value
+        self.integral += error * dt
+        self.integral = float(np.clip(self.integral, -self.integral_clip, self.integral_clip))
+        derivative = (error - self.last_error) / dt if dt > 0.0 else 0.0
+
+        u = (self.kp * error) + (self.ki * self.integral) + (self.kd * derivative)
+
+        abs_e = abs(error)
+        abs_last_e = abs(self.last_error)
+        big_err = self.big_error_threshold
+
+        if abs_e > big_err and abs_e >= abs_last_e:
+            self.kp *= 1.0 + self.adapt_rate_p * dt
+            self.ki *= 1.0 + self.adapt_rate_i * dt
+
+        if np.sign(error) != np.sign(self.last_error) and abs_last_e > big_err:
+            self.kp *= 1.0 - self.adapt_rate_p * dt
+            self.ki *= 1.0 - self.adapt_rate_i * dt
+            self.kd *= 1.0 + self.adapt_rate_d * dt
+
+        self.kp = float(np.clip(self.kp, 0.2 * self.kp0, 5.0 * self.kp0))
+        self.ki = float(np.clip(self.ki, 0.2 * self.ki0, 5.0 * self.ki0))
+        self.kd = float(np.clip(self.kd, 0.2 * self.kd0, 5.0 * self.kd0))
+
+        self.last_error = error
+        return float(u)
+
+
+# =============================================================================
+# SUPERVISOR
+# =============================================================================
+def supervisor(Ppre_cmd, Pmain_cmd, e2, e3, deadband_K=1.0, scale_min=0.3):
+    if not SUPERVISOR_ON:
+        return Ppre_cmd, Pmain_cmd
+    if abs(e2) < deadband_K and abs(e3) < deadband_K:
+        return max(Ppre_cmd * scale_min, 0.0), max(Pmain_cmd * scale_min, 0.0)
+    return Ppre_cmd, Pmain_cmd
+
+
+# =============================================================================
+# TRANSIENT PLANT
+# =============================================================================
+def plant_step_transient(
+    h,
+    p,
+    x,
+    W_int,
+    A_cs,
+    Perim,
+    Dh,
+    p0,
+    T_inlet,
+    specie,
+    L_inlet,
+    L_uCh,
+    L_int,
+    dx,
+    mass_flow,
+    P_pre,
+    P_main,
+    dt_fixed,
+):
+    n = len(h)
+    rtd2 = find_nearest_index(x, L_inlet + L_uCh)
+    rtd3 = find_nearest_index(x, L_int)
+
+    p[0] = float(max(p0, 1e3))
+    h[0] = float(CP.PropsSI("H", "P", p[0], "T", T_inlet, specie))
+
+    n_pre = max(rtd2, 1)
+    n_main = max(rtd3 - rtd2, 1)
+
+    Q = np.zeros(n)
+    for i in range(n):
+        if i < rtd2:
+            Q[i] = P_pre / n_pre
+        elif i < rtd3:
+            Q[i] = P_main / n_main
+        else:
+            Q[i] = 0.0
+
+    T_fl = np.zeros(n)
+    T_w = np.zeros(n)
+
+    h_new = h.copy()
+    p_new = p.copy()
+
+    for i in range(1, n):
+        p_i = float(max(p[i], 1e3))
+
+        try:
+            T_i = CP.PropsSI("T", "P", p_i, "H", h[i], specie)
+        except Exception:
+            hL = CP.PropsSI("H", "P", p_i, "Q", 0, specie)
+            hV = CP.PropsSI("H", "P", p_i, "Q", 1, specie)
+            h[i] = float(np.clip(h[i], hL - 2e5, hV + 2e5))
+            T_i = CP.PropsSI("T", "P", p_i, "H", h[i], specie)
+
+        rho = CP.PropsSI("D", "P", p_i, "H", h[i], specie)
+
+        phase = CP.PhaseSI("P", p_i, "HMASS", h[i], specie)
+        phase_l = phase.lower()
+        if "liquid" in phase_l and "twophase" not in phase_l:
+            x_v = 0.0
+        elif any(tag in phase_l for tag in ["gas", "supercritical", "supercritical_gas"]):
+            x_v = 1.0
+        else:
+            rhoV = CP.PropsSI("D", "P", p_i, "Q", 1, specie)
+            rhoL = CP.PropsSI("D", "P", p_i, "Q", 0, specie)
+            denom = rhoL - rhoV
+            x_v = float(np.clip((rhoL - rho) / denom, 0.0, 1.0)) if abs(denom) > 0 else 0.0
+
+        kL = CP.PropsSI("L", "P", p_i, "Q", 0, specie)
+        kV = CP.PropsSI("L", "P", p_i, "Q", 1, specie)
+        k_mix = kV * x_v + kL * (1.0 - x_v)
+
+        muL = CP.PropsSI("V", "P", p_i, "Q", 0, specie)
+        muV = CP.PropsSI("V", "P", p_i, "Q", 1, specie)
+        mu_mix = muV * x_v + muL * (1.0 - x_v)
+
+        A_flow = float(W_int[i] * H_int)
+        v = mass_flow / (rho * A_flow + EPS)
+        CFL = float(np.clip(v * dt_fixed / (dx + EPS), 0.0, 1.0))
+
+        dh_src = CFL * (Q[i] / (mass_flow + EPS))
+        h_new[i] = h[i] - CFL * (h[i] - h[i - 1]) + dh_src
+
+        dp = 12.0 * mu_mix * (v / (H_int**2 + EPS)) * dx
+        p_new[i] = float(max(p_new[i - 1] - dp, 1e3))
+
+        Nu = 4.96
+        hc = Nu * k_mix / (Dh[i] + EPS)
+
+        if i < rtd2:
+            qflux = Q[i] / (Perim[i] * dx + EPS)
+        elif i < rtd3:
+            qflux = Q[i] / (W_int[i] * dx + EPS)
+        else:
+            qflux = 0.0
+
+        try:
+            T_new = CP.PropsSI("T", "P", p_new[i], "H", h_new[i], specie)
+        except Exception:
+            p_tmp = float(max(p_new[i], 1e3))
+            hL2 = CP.PropsSI("H", "P", p_tmp, "Q", 0, specie)
+            hV2 = CP.PropsSI("H", "P", p_tmp, "Q", 1, specie)
+            h_new[i] = float(np.clip(h_new[i], hL2 - 2e5, hV2 + 2e5))
+            T_new = CP.PropsSI("T", "P", p_tmp, "H", h_new[i], specie)
+
+        T_fl[i] = float(T_new)
+        T_w[i] = qflux / (hc + EPS) + float(T_new)
+
+    T_fl[0] = T_inlet
+    T_w[0] = T_inlet
+
+    return h_new, p_new, T_fl, T_w
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+def main():
+    xg, Wg, Acs, Perim, Dh = calculate_parameters(
+        n_it,
+        L_int,
+        W_intDiv2,
+        alpha_intDiv1,
+        W_inlet,
+        L_inlet,
+        L_uCh,
+        L_intDiv,
+        channelNum,
+        channelWidth,
+        finNum,
+        finWidth,
+        H_int,
+    )
+    rtd2 = find_nearest_index(xg, L_inlet + L_uCh)
+    rtd3 = find_nearest_index(xg, L_int)
+
+    frac_pre = float(np.clip(xg[rtd2] / L_ext, 0.0, 1.0)) if L_ext > 0 else 0.5
+    frac_main = float(np.clip((xg[rtd3] - xg[rtd2]) / L_ext, 0.0, 1.0)) if L_ext > 0 else 0.5
+    A_pre = A_ext * frac_pre
+    A_main = A_ext * frac_main
+
+    pid2 = AdaptivePIDNN()
+    pid3 = AdaptivePIDNN()
+
+    Ppre_applied = 0.0
+    Pmain_applied = 0.0
+
+    h0 = float(CP.PropsSI("H", "P", p_start, "T", T_fl_start, specie))
+    h = np.ones(n_it) * h0
+    p = np.ones(n_it) * float(p_start)
+
+    time = np.zeros(n_steps)
+    T2_hist = np.zeros(n_steps)
+    Tw2_hist = np.zeros(n_steps)
+    T3_hist = np.zeros(n_steps)
+    Tw3_hist = np.zeros(n_steps)
+    SP2_hist = np.zeros(n_steps)
+    SP3_hist = np.zeros(n_steps)
+
+    u2_raw = np.zeros(n_steps)
+    u3_raw = np.zeros(n_steps)
+
+    # adaptive PID gain histories
+    kp2_hist = np.zeros(n_steps); ki2_hist = np.zeros(n_steps); kd2_hist = np.zeros(n_steps)
+    kp3_hist = np.zeros(n_steps); ki3_hist = np.zeros(n_steps); kd3_hist = np.zeros(n_steps)
+
+    Ppre_applied_hist = np.zeros(n_steps)
+    Pmain_applied_hist = np.zeros(n_steps)
+    d_pre_hist = np.zeros(n_steps)
+    d_main_hist = np.zeros(n_steps)
+    Ppre_cmd_next_hist = np.zeros(n_steps)
+    Pmain_cmd_next_hist = np.zeros(n_steps)
+
+    noz_T0 = np.zeros(n_steps)
+    noz_P0 = np.zeros(n_steps)
+    noz_xvap_raw = np.zeros(n_steps)
+    noz_xvap_clip = np.zeros(n_steps)
+    noz_mdot_act = np.zeros(n_steps)
+    noz_ue = np.zeros(n_steps)
+    noz_eta_u = np.zeros(n_steps)
+
+    for k in tqdm(range(1, n_steps), desc="Simulating", dynamic_ncols=True):
+        t = k * FIXED_DT
+        time[k] = t
+
+        h, p, T_fl, T_wall = plant_step_transient(
+            h,
+            p,
+            xg,
+            Wg,
+            Acs,
+            Perim,
+            Dh,
+            p_start,
+            T_fl_start,
+            specie,
+            L_inlet,
+            L_uCh,
+            L_int,
+            dx,
+            mass_flow,
+            Ppre_applied,
+            Pmain_applied,
+            FIXED_DT,
+        )
+
+        T2 = float(T_fl[rtd2])
+        Tw2 = float(T_wall[rtd2])
+        T3 = float(T_fl[rtd3])
+        Tw3 = float(T_wall[rtd3])
+
+        T0 = float(T3)
+        P0 = float(p[rtd3])
+        x_exit_raw = quality_from_hP(float(h[rtd3]), float(p[rtd3]), specie=specie, clip=False)
+        x_exit_clip = quality_from_hP(float(h[rtd3]), float(p[rtd3]), specie=specie, clip=True)
+
+        m_dot_act, u_e, eta_u = nozzle_metrics(T0, P0, x_exit_clip, specie=specie)
+
+        noz_T0[k] = T0
+        noz_P0[k] = P0
+        noz_xvap_raw[k] = x_exit_raw
+        noz_xvap_clip[k] = x_exit_clip
+        noz_mdot_act[k] = m_dot_act
+        noz_ue[k] = u_e
+        noz_eta_u[k] = eta_u
+
+        T2_hist[k] = T2
+        Tw2_hist[k] = Tw2
+        T3_hist[k] = T3
+        Tw3_hist[k] = Tw3
+
+        SP2 = float(setpoint_rtd2(t))
+        SP3 = float(setpoint_rtd3(t))
+        SP2_hist[k] = SP2
+        SP3_hist[k] = SP3
+
+        e2 = SP2 - T2
+        e3 = SP3 - T3
+
+        u2 = float(pid2.update(T2, SP2, FIXED_DT))
+        u3 = float(pid3.update(T3, SP3, FIXED_DT))
+        u2_raw[k] = u2
+        u3_raw[k] = u3
+
+        kp2_hist[k], ki2_hist[k], kd2_hist[k] = pid2.kp, pid2.ki, pid2.kd
+        kp3_hist[k], ki3_hist[k], kd3_hist[k] = pid3.kp, pid3.ki, pid3.kd
+
+        Tw_pre = float(np.mean(T_wall[: max(rtd2, 1)]))
+        Tw_main = float(np.mean(T_wall[rtd2 : max(rtd3, rtd2 + 1)]))
+
+        losses_pre = (
+            calculation_P_rad(Tw_pre, T_ambient, em, sigma_stef_boltz, A_pre)
+            + calculation_P_conv(h_conv_ext, Tw_pre, T_ambient, A_pre)
+            + 0.001 * calculation_P_cond_struct(k_Si, Tw_pre, T_ambient, A_pre, L_ext)
+        )
+        losses_main = (
+            calculation_P_rad(Tw_main, T_ambient, em, sigma_stef_boltz, A_main)
+            + calculation_P_conv(h_conv_ext, Tw_main, T_ambient, A_main)
+            + 0.001 * calculation_P_cond_struct(k_Si, Tw_main, T_ambient, A_main, L_ext)
+        )
+        losses_pre = float(max(losses_pre, 0.0))
+        losses_main = float(max(losses_main, 0.0))
+
+        if e2 > deadband:
+            d_pre_cmd_next = float(np.clip(u2, 0.0, 1.0))
+        elif e2 < -deadband:
+            d_pre_cmd_next = 0.0
+        else:
+            d_pre_cmd_next = float(np.clip(losses_pre / (q_max + EPS), 0.0, 1.0))
+
+        if e3 > deadband:
+            d_main_cmd_next = float(np.clip(u3, 0.0, 1.0))
+        elif e3 < -deadband:
+            d_main_cmd_next = 0.0
+        else:
+            d_main_cmd_next = float(np.clip(losses_main / (q_max + EPS), 0.0, 1.0))
+
+        Ppre_cmd_next = d_pre_cmd_next * float(q_max)
+        Pmain_cmd_next = d_main_cmd_next * float(q_max)
+
+        Ppre_cmd_next, Pmain_cmd_next = supervisor(Ppre_cmd_next, Pmain_cmd_next, e2, e3)
+
+        Ppre_applied_hist[k] = Ppre_applied
+        Pmain_applied_hist[k] = Pmain_applied
+        Ppre_cmd_next_hist[k] = Ppre_cmd_next
+        Pmain_cmd_next_hist[k] = Pmain_cmd_next
+
+        if PRINT_EVERY and (k % PRINT_EVERY == 0 or k == n_steps - 1):
+            print(
+                f"k={k:5d} t={t:8.3f}s dt={FIXED_DT:0.4f}s | "
+                f"SP2={SP2:7.2f}K T2_fl={T2:7.2f}K T2_w={Tw2:7.2f}K e2={e2:8.2f} | "
+                f"SP3={SP3:7.2f}K T3_fl={T3:7.2f}K T3_w={Tw3:7.2f}K e3={e3:8.2f} | "
+                f"u2_raw(duty)={u2:7.3f} u3_raw(duty)={u3:7.3f} | "
+                f"Ppre_cmd(next)={Ppre_cmd_next:7.3f}W Pmain_cmd(next)={Pmain_cmd_next:7.3f}W | "
+                f"Ppre_applied(now)={Ppre_applied:7.3f}W Pmain_applied(now)={Pmain_applied:7.3f}W"
+            )
+
+        _Pmax_pre = float(q_max) if P_MAX_PRE is None else float(P_MAX_PRE)
+        _Pmax_main = float(q_max) if P_MAX_MAIN is None else float(P_MAX_MAIN)
+
+        d_pre = duty_from_power(Ppre_cmd_next, _Pmax_pre)
+        d_main = duty_from_power(Pmain_cmd_next, _Pmax_main)
+
+        if PWM_ON:
+            g_pre = pwm_gate(t, d_pre, PWM_PERIOD)
+            g_main = pwm_gate(t, d_main, PWM_PERIOD)
+            Ppre_applied = g_pre * _Pmax_pre
+            Pmain_applied = g_main * _Pmax_main
+        else:
+            Ppre_applied = Ppre_cmd_next
+            Pmain_applied = Pmain_cmd_next
+
+        d_pre_hist[k] = d_pre
+        d_main_hist[k] = d_main
+
+    def plot_heater_panel(rtd_tag, T_fl_hist, T_w_hist, SP_hist, P_hist, kp_hist, ki_hist, kd_hist):
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(14, 12), sharex=True)
+
+        ax1.plot(time, T_fl_hist, label=f"Fluid Temperature @ {rtd_tag} [K]")
+        ax1.plot(time, T_w_hist, "--", label=f"Wall Temperature @ {rtd_tag} [K]")
+        ax1.plot(time, SP_hist, "-.", label="Setpoint Temperature [K]")
+        ax1.set_title(f"Temperature Profile Over Time ({rtd_tag})")
+        ax1.set_ylabel("T [K]")
+        ax1.grid(True)
+        ax1.legend(loc="upper right")
+
+        ax2.plot(time, P_hist, label="Heat Input (W)")
+        e_total = float(np.trapz(P_hist, time))
+        avg_power = float(np.mean(P_hist))
+        ax2.text(
+            0.60,
+            0.62,
+            f"Total Heat Input = {e_total:.2f} J\nAverage Power = {avg_power:.2f} W",
+            transform=ax2.transAxes,
+            bbox=dict(facecolor="white", alpha=0.8),
+        )
+        ax2.set_title(f"Heat Input Over Time ({rtd_tag})")
+        ax2.set_ylabel("H_input [W]")
+        ax2.grid(True)
+        ax2.legend(loc="upper right")
+
+        ax3.plot(time, kp_hist, label="Kp")
+        ax3.plot(time, ki_hist, label="Ki")
+        ax3.plot(time, kd_hist, label="Kd")
+        ax3.set_title(f"PID Parameters Over Time ({rtd_tag})")
+        ax3.set_xlabel("t [s]")
+        ax3.set_ylabel("PID Values")
+        ax3.grid(True)
+        ax3.legend(loc="upper right")
+
+        fig.tight_layout()
+
+    plot_heater_panel("RTD2", T2_hist, Tw2_hist, SP2_hist, Ppre_applied_hist, kp2_hist, ki2_hist, kd2_hist)
+    plot_heater_panel("RTD3", T3_hist, Tw3_hist, SP3_hist, Pmain_applied_hist, kp3_hist, ki3_hist, kd3_hist)
+
+    plt.figure(figsize=(14, 10))
+
+    cx1 = plt.subplot(3, 2, 1)
+    cx1.plot(time, noz_T0, label="T0 [K]")
+    cx1.set_title("Nozzle Inlet Temperature T0")
+    cx1.set_xlabel("Time [s]")
+    cx1.set_ylabel("T0 [K]")
+    cx1.grid(True)
+
+    cx2 = plt.subplot(3, 2, 2)
+    cx2.plot(time, noz_P0 / 1e5, label="P0 [bar]")
+    cx2.set_title("Nozzle Inlet Pressure P0")
+    cx2.set_xlabel("Time [s]")
+    cx2.set_ylabel("P0 [bar]")
+    cx2.grid(True)
+
+    cx3 = plt.subplot(3, 2, 3)
+    cx3.plot(time, noz_xvap_raw, label="x_vap_exit RAW [-]")
+    cx3.plot(time, noz_xvap_clip, "--", label="x_vap_exit clipped [-]")
+    cx3.set_title("Vapour Quality at Heater Exit (post-heat-control)")
+    cx3.set_xlabel("Time [s]")
+    cx3.set_ylabel("x_vap_exit [-]")
+    cx3.grid(True)
+    cx3.legend()
+
+    cx4 = plt.subplot(3, 2, 4)
+    cx4.plot(time, noz_mdot_act * 1e9, label="m_dot_act [µg/s]")
+    cx4.set_title("Effective Mass Flow Through Nozzle")
+    cx4.set_xlabel("Time [s]")
+    cx4.set_ylabel("m_dot_act [µg/s]")
+    cx4.grid(True)
+
+    cx5 = plt.subplot(3, 2, 5)
+    cx5.plot(time, noz_ue, label="u_e [m/s]")
+    cx5.set_title("Exit Velocity u_e")
+    cx5.set_xlabel("Time [s]")
+    cx5.set_ylabel("u_e [m/s]")
+    cx5.grid(True)
+
+    cx6 = plt.subplot(3, 2, 6)
+    cx6.plot(time, noz_eta_u, label="eta_u [-]")
+    cx6.set_title("Boundary-Layer Efficiency η_u")
+    cx6.set_xlabel("Time [s]")
+    cx6.set_ylabel("η_u [-]")
+    cx6.set_ylim(-0.05, 1.05)
+    cx6.grid(True)
+
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -24,7 +24,7 @@ EPS = 1e-30  # tiny number to prevent division-by-zero
 # =========================
 # PWM / Duty-cycle actuation (paper-like power spikes)
 # =========================
-PWM_ON = False
+PWM_ON = True
 PWM_PERIOD = 0.50
 P_MAX_PRE = None
 P_MAX_MAIN = None

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -553,11 +553,23 @@ def plant_step_transient(
 
     Qdot_f_pre_sum = 0.0
     Qdot_f_main_sum = 0.0
+    cfl_clip_count = 0
+
+    qdot_raw = np.zeros(n)
+    cfl_arr = np.zeros(n)
+    zone_tag = np.full(n, "none", dtype=object)
+    T_old = np.zeros(n)
+
+    pre_t_sum = 0.0
+    pre_t_n = 0
+    main_t_sum = 0.0
+    main_t_n = 0
 
     for i in range(1, n):
         p_i = float(max(p[i], 1e3))
 
         T_i = robust_temperature_from_ph(p_i, h[i], specie)
+        T_old[i] = float(T_i)
 
         hL_loc = CP.PropsSI("H", "P", p_i, "Q", 0, specie)
         hV_loc = CP.PropsSI("H", "P", p_i, "Q", 1, specie)
@@ -586,7 +598,11 @@ def plant_step_transient(
 
         A_flow = float(W_int[i] * H_int)
         v = mass_flow / (rho * A_flow + EPS)
-        CFL = float(np.clip(v * dt_fixed / (dx + EPS), 0.0, 1.0))
+        cfl_raw = v * dt_fixed / (dx + EPS)
+        if cfl_raw > 1.0:
+            cfl_clip_count += 1
+        CFL = float(np.clip(cfl_raw, 0.0, 1.0))
+        cfl_arr[i] = CFL
 
         dp = 12.0 * mu_mix * (v / (H_int**2 + EPS)) * dx
         p_new[i] = float(max(p_new[i - 1] - dp, 1e3))
@@ -594,9 +610,13 @@ def plant_step_transient(
         if i < rtd2:
             Tw_loc = float(Tw_pre_zone)
             zone = "pre"
+            pre_t_sum += float(T_i)
+            pre_t_n += 1
         elif i < rtd3:
             Tw_loc = float(Tw_main_zone)
             zone = "main"
+            main_t_sum += float(T_i)
+            main_t_n += 1
         else:
             Tw_loc = float(T_i)
             zone = "none"
@@ -604,17 +624,50 @@ def plant_step_transient(
         hb_nom = NU_BASE * k_mix / (Dh[i] + EPS)
         q_flux_dem = max(0.0, hb_nom * (Tw_loc - float(T_i)))
 
-        hb = hb_nom
         A_ex_i = float(Perim[i] * dx)
         Qdot_f_i = q_flux_dem * A_ex_i
+
+        zone_tag[i] = zone
+        qdot_raw[i] = float(Qdot_f_i)
 
         if zone == "pre":
             Qdot_f_pre_sum += Qdot_f_i
         elif zone == "main":
             Qdot_f_main_sum += Qdot_f_i
 
-        dh_src = Qdot_f_i * dt_fixed / (mass_flow + EPS)
-        h_new[i] = h[i] - CFL * (h[i] - h[i - 1]) + dh_src
+    Tref_pre = float(pre_t_sum / pre_t_n) if pre_t_n > 0 else float(T_inlet)
+    Tref_main = float(main_t_sum / main_t_n) if main_t_n > 0 else float(T_old[min(max(rtd2, 1), n - 1)])
+
+    pre_available = max(P_pre_net, 0.0) + max(Cw_pre, EPS) * max(Tw_pre_zone - Tref_pre, 0.0) / max(dt_fixed, EPS)
+    main_available = max(P_main_net, 0.0) + max(Cw_main, EPS) * max(Tw_main_zone - Tref_main, 0.0) / max(dt_fixed, EPS)
+
+    Qdot_f_pre_sum_raw = float(Qdot_f_pre_sum)
+    Qdot_f_main_sum_raw = float(Qdot_f_main_sum)
+    scale_pre = float(min(1.0, pre_available / (Qdot_f_pre_sum_raw + 1e-12)))
+    scale_main = float(min(1.0, main_available / (Qdot_f_main_sum_raw + 1e-12)))
+
+    Qdot_f_pre_sum = 0.0
+    Qdot_f_main_sum = 0.0
+
+    T_fl[0] = T_inlet
+    T_w[0] = float(Tw_pre_zone)
+
+    for i in range(1, n):
+        zone = zone_tag[i]
+        if zone == "pre":
+            qdot_i = qdot_raw[i] * scale_pre
+            Tw_loc = float(Tw_pre_zone)
+            Qdot_f_pre_sum += qdot_i
+        elif zone == "main":
+            qdot_i = qdot_raw[i] * scale_main
+            Tw_loc = float(Tw_main_zone)
+            Qdot_f_main_sum += qdot_i
+        else:
+            qdot_i = qdot_raw[i]
+            Tw_loc = float(T_old[i])
+
+        dh_src = qdot_i * dt_fixed / (mass_flow + EPS)
+        h_new[i] = h[i] - cfl_arr[i] * (h[i] - h[i - 1]) + dh_src
 
         T_new = robust_temperature_from_ph(p_new[i], h_new[i], specie)
         T_fl[i] = float(T_new)
@@ -624,23 +677,6 @@ def plant_step_transient(
             T_w[i] = float(Tw_main_zone)
         else:
             T_w[i] = float(T_new)
-
-    pre_zone_mask = slice(1, max(rtd2, 1))
-    main_zone_mask = slice(max(rtd2, 1), max(rtd3, rtd2 + 1))
-    Tref_pre = float(np.mean(T_fl[pre_zone_mask])) if (max(rtd2, 1) - 1) > 0 else float(T_inlet)
-    main_fallback_idx = min(max(rtd2, 1), n - 1)
-    Tref_main = float(np.mean(T_fl[main_zone_mask])) if (max(rtd3, rtd2 + 1) - max(rtd2, 1)) > 0 else float(T_fl[main_fallback_idx])
-
-    pre_available = max(P_pre_net, 0.0) + max(Cw_pre, EPS) * max(Tw_pre_zone - Tref_pre, 0.0) / max(dt_fixed, EPS)
-    main_available = max(P_main_net, 0.0) + max(Cw_main, EPS) * max(Tw_main_zone - Tref_main, 0.0) / max(dt_fixed, EPS)
-
-    Qdot_f_pre_sum_raw = float(Qdot_f_pre_sum)
-    Qdot_f_main_sum_raw = float(Qdot_f_main_sum)
-    scale_pre = float(min(1.0, pre_available / (Qdot_f_pre_sum_raw + 1e-12)))
-    scale_main = float(min(1.0, main_available / (Qdot_f_main_sum_raw + 1e-12)))
-    Qdot_f_pre_sum = Qdot_f_pre_sum_raw * scale_pre
-    Qdot_f_main_sum = Qdot_f_main_sum_raw * scale_main
-
     Tw_pre_next = float(Tw_pre_zone + dt_fixed * (max(P_pre_net, 0.0) - Qdot_f_pre_sum) / max(Cw_pre, EPS))
     Tw_main_next = float(Tw_main_zone + dt_fixed * (max(P_main_net, 0.0) - Qdot_f_main_sum) / max(Cw_main, EPS))
 
@@ -656,6 +692,7 @@ def plant_step_transient(
         "main_qavail": float(main_available),
         "pre_scale": float(scale_pre),
         "main_scale": float(scale_main),
+        "cfl_clip_count": int(cfl_clip_count),
     }
 
     return h_new, p_new, T_fl, T_w, Tw_pre_next, Tw_main_next, conv_diag
@@ -740,6 +777,7 @@ def main():
     dt_hist = np.zeros(n_steps)
     conv_overdraw_pre_hist = np.zeros(n_steps)
     conv_overdraw_main_hist = np.zeros(n_steps)
+    cfl_clip_count_hist = np.zeros(n_steps)
 
     SP2_f = float(setpoint_rtd2(0.0))
     SP3_f = float(setpoint_rtd3(0.0))
@@ -854,6 +892,7 @@ def main():
 
         conv_overdraw_pre_hist[k] = max(0.0, conv_diag["pre_qconv_raw"] - conv_diag["pre_qavail"])
         conv_overdraw_main_hist[k] = max(0.0, conv_diag["main_qconv_raw"] - conv_diag["main_qavail"])
+        cfl_clip_count_hist[k] = conv_diag["cfl_clip_count"]
 
         if e2 > deadband:
             d_pre_cmd_next = float(np.clip(u2, 0.0, 1.0))

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -323,11 +323,23 @@ class AdaptivePIDNN:
 
     def update(self, current_value, setpoint, dt):
         error = setpoint - current_value
+
+        # Leaky integrator reduces long-memory lock-in after large overshoot events.
+        self.integral *= 0.999
         self.integral += error * dt
         self.integral = float(np.clip(self.integral, -self.integral_clip, self.integral_clip))
-        derivative = (error - self.last_error) / dt if dt > 0.0 else 0.0
 
+        derivative = (error - self.last_error) / dt if dt > 0.0 else 0.0
         u = (self.kp * error) + (self.ki * self.integral) + (self.kd * derivative)
+
+        # Sign-consistent anti-windup: if control action fights the current error,
+        # bleed integral in the opposite direction and recompute u.
+        if error > 0.0 and u < 0.0:
+            self.integral = max(self.integral, 0.0)
+            u = (self.kp * error) + (self.ki * self.integral) + (self.kd * derivative)
+        elif error < 0.0 and u > 0.0:
+            self.integral = min(self.integral, 0.0)
+            u = (self.kp * error) + (self.ki * self.integral) + (self.kd * derivative)
 
         abs_e = abs(error)
         abs_last_e = abs(self.last_error)
@@ -367,6 +379,7 @@ def allocate_min_power(Ppre_cmd, Pmain_cmd, e2, e3, losses_pre, losses_main, dea
     - Prioritize main-heater power for RTD3 tracking.
     - Disable preheater unless both sections are cold and RTD3 still needs heat.
     - In the near-setpoint region, only apply loss-compensation power.
+    - Enforce minimum RTD3 recovery power when RTD3 is far below setpoint.
     """
     # Any RTD3 overshoot: stop active heating to avoid oscillatory re-heating.
     if e3 < -deadband_K:
@@ -378,6 +391,12 @@ def allocate_min_power(Ppre_cmd, Pmain_cmd, e2, e3, losses_pre, losses_main, dea
     # Near setpoint: only hold estimated thermal losses.
     if abs(e3) <= 2.0 * deadband_K and abs(e2) <= 2.0 * deadband_K:
         return float(np.clip(losses_pre, 0.0, q_max)), float(np.clip(losses_main, 0.0, q_max))
+
+    # Guarantee a non-zero recovery action for RTD3 when far below target,
+    # even if PID raw output briefly goes negative due to integral history.
+    if e3 > 3.0 * deadband_K:
+        min_recovery = max(0.10 * q_max, losses_main)
+        Pmain = max(Pmain, min_recovery)
 
     # RTD3 gets primary authority; preheater acts only as assist when both are cold.
     if not (e3 > 2.0 * deadband_K and e2 > deadband_K):

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -334,9 +334,9 @@ def setpoint_rtd3(t):
 
 
 # =============================================================================
-# ADAPTIVE PID
+# ERROR-BASED ADAPTIVE PID
 # =============================================================================
-class AdaptivePIDNN:
+class AdaptivePIDErrorBased:
     def __init__(
         self,
         kp0=0.0005,
@@ -603,8 +603,8 @@ def main():
     A_pre = A_ext * frac_pre
     A_main = A_ext * frac_main
 
-    pid2 = AdaptivePIDNN(u_max=1.0)
-    pid3 = AdaptivePIDNN(u_max=1.0)
+    pid2 = AdaptivePIDErrorBased(u_max=1.0)
+    pid3 = AdaptivePIDErrorBased(u_max=1.0)
 
     Ppre_applied = 0.0
     Pmain_applied = 0.0
@@ -644,6 +644,12 @@ def main():
     noz_mdot_act = np.zeros(n_steps)
     noz_ue = np.zeros(n_steps)
     noz_eta_u = np.zeros(n_steps)
+
+    # performance / power metrics for paper-style comparison
+    F_act = np.zeros(n_steps)
+    Isp_act = np.zeros(n_steps)
+    Ptot_cmd_before_losses_hist = np.zeros(n_steps)
+    Ptot_applied_hist = np.zeros(n_steps)
 
     SP2_f = float(setpoint_rtd2(0.0))
     SP3_f = float(setpoint_rtd3(0.0))
@@ -704,6 +710,11 @@ def main():
         noz_ue[k] = u_e
         noz_eta_u[k] = eta_u
 
+        F = float(m_dot_act * u_e * eta_u)
+        Isp = float(F / (m_dot_act * g0 + 1e-8)) if m_dot_act > 0.0 else 0.0
+        F_act[k] = F
+        Isp_act[k] = Isp
+
         T2_hist[k] = T2
         Tw2_hist[k] = Tw2
         T3_hist[k] = T3
@@ -725,6 +736,10 @@ def main():
         u3 = float(pid3.update(T3, SP3_f, FIXED_DT))
         u2_raw[k] = u2
         u3_raw[k] = u3
+
+        # Paper-style comparison metric: total commanded heater power before
+        # any loss-compensation hold logic and supervisory allocation layers.
+        Ptot_cmd_before_losses_hist[k] = (float(np.clip(u2, 0.0, 1.0)) + float(np.clip(u3, 0.0, 1.0))) * q_max
 
         kp2_hist[k], ki2_hist[k], kd2_hist[k] = pid2.kp, pid2.ki, pid2.kd
         kp3_hist[k], ki3_hist[k], kd3_hist[k] = pid3.kp, pid3.ki, pid3.kd
@@ -803,6 +818,7 @@ def main():
 
         Ppre_applied_hist[k] = Ppre_applied
         Pmain_applied_hist[k] = Pmain_applied
+        Ptot_applied_hist[k] = Ppre_applied + Pmain_applied
         Ppre_cmd_next_hist[k] = Ppre_cmd_next
         Pmain_cmd_next_hist[k] = Pmain_cmd_next
 
@@ -832,6 +848,7 @@ def main():
                 f"SP2={SP2:7.2f}K T2_fl={T2:7.2f}K T2_w={Tw2:7.2f}K e2={e2:8.2f} | "
                 f"SP3={SP3:7.2f}K T3_fl={T3:7.2f}K T3_w={Tw3:7.2f}K e3={e3:8.2f} | "
                 f"u2_raw(duty)={u2:7.3f} u3_raw(duty)={u3:7.3f} | "
+                f"Ptot_cmd_before_losses={Ptot_cmd_before_losses_hist[k]:7.3f}W | "
                 f"Ppre_cmd(next)={Ppre_cmd_next:7.3f}W Pmain_cmd(next)={Pmain_cmd_next:7.3f}W | "
                 f"Ppre_applied(now)={Ppre_applied:7.3f}W Pmain_applied(now)={Pmain_applied:7.3f}W | "
                 f"d_pre={d_pre:5.3f} d_main={d_main:5.3f} act_pre(next)={g_pre:5.3f} act_main(next)={g_main:5.3f}"
@@ -882,6 +899,33 @@ def main():
 
     plot_heater_panel("RTD2", T2_hist, Tw2_hist, SP2_f_hist, Ppre_applied_hist, kp2_hist, ki2_hist, kd2_hist)
     plot_heater_panel("RTD3", T3_hist, Tw3_hist, SP3_f_hist, Pmain_applied_hist, kp3_hist, ki3_hist, kd3_hist)
+
+    sim_time = float(time[-1]) if time[-1] > 0.0 else 1.0
+    Etot_cmd_before_losses = float(np.trapz(Ptot_cmd_before_losses_hist, time))
+    Pavg_cmd_before_losses = Etot_cmd_before_losses / sim_time
+    Etot_applied_total = float(np.trapz(Ptot_applied_hist, time))
+    Pavg_applied_total = Etot_applied_total / sim_time
+    print("\n=== Paper-style power comparison ===")
+    print(f"Total commanded power before loss compensation: E_tot={Etot_cmd_before_losses:.3f} J, P_avg={Pavg_cmd_before_losses:.3f} W")
+    print(f"Total applied heater power (pre+main):          E_tot={Etot_applied_total:.3f} J, P_avg={Pavg_applied_total:.3f} W")
+
+    plt.figure(figsize=(10, 8))
+    tx1 = plt.subplot(2, 1, 1)
+    tx1.plot(time, F_act * 1e3, label="Thrust [mN]")
+    tx1.set_title("Thrust Over Time")
+    tx1.set_xlabel("Time [s]")
+    tx1.set_ylabel("Thrust [mN]")
+    tx1.grid(True)
+    tx1.legend()
+
+    tx2 = plt.subplot(2, 1, 2)
+    tx2.plot(time, Isp_act, label="Isp [s]")
+    tx2.set_title("Specific Impulse Over Time")
+    tx2.set_xlabel("Time [s]")
+    tx2.set_ylabel("Isp [s]")
+    tx2.grid(True)
+    tx2.legend()
+    plt.tight_layout()
 
     plt.figure(figsize=(14, 10))
 

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -24,7 +24,7 @@ EPS = 1e-30  # tiny number to prevent division-by-zero
 # =========================
 # PWM / Duty-cycle actuation (paper-like power spikes)
 # =========================
-PWM_ON = True
+PWM_ON = False
 PWM_PERIOD = 0.50
 P_MAX_PRE = None
 P_MAX_MAIN = None
@@ -190,8 +190,6 @@ def nozzle_metrics(T0, P0, x_vap, specie="Water"):
 
 q_max = 20.0
 deadband = 1.0
-POWER_SPLIT_PRE = 0.5
-POWER_SPLIT_MAIN = 0.5
 
 
 # =============================================================================
@@ -361,6 +359,31 @@ def supervisor(Ppre_cmd, Pmain_cmd, e2, e3, deadband_K=1.0, scale_min=0.3):
     if abs(e2) < deadband_K and abs(e3) < deadband_K:
         return max(Ppre_cmd * scale_min, 0.0), max(Pmain_cmd * scale_min, 0.0)
     return Ppre_cmd, Pmain_cmd
+
+
+def allocate_min_power(Ppre_cmd, Pmain_cmd, e2, e3, losses_pre, losses_main, deadband_K=1.0):
+    """Energy-aware allocator.
+
+    - Prioritize main-heater power for RTD3 tracking.
+    - Disable preheater unless both sections are cold and RTD3 still needs heat.
+    - In the near-setpoint region, only apply loss-compensation power.
+    """
+    # Any RTD3 overshoot: stop active heating to avoid oscillatory re-heating.
+    if e3 < -deadband_K:
+        return 0.0, 0.0
+
+    Ppre = max(Ppre_cmd, 0.0)
+    Pmain = max(Pmain_cmd, 0.0)
+
+    # Near setpoint: only hold estimated thermal losses.
+    if abs(e3) <= 2.0 * deadband_K and abs(e2) <= 2.0 * deadband_K:
+        return float(np.clip(losses_pre, 0.0, q_max)), float(np.clip(losses_main, 0.0, q_max))
+
+    # RTD3 gets primary authority; preheater acts only as assist when both are cold.
+    if not (e3 > 2.0 * deadband_K and e2 > deadband_K):
+        Ppre = 0.0
+
+    return float(np.clip(Ppre, 0.0, q_max)), float(np.clip(Pmain, 0.0, q_max))
 
 
 # =============================================================================
@@ -649,12 +672,15 @@ def main():
         Pmain_cmd_next = d_main_cmd_next * float(q_max)
 
         Ppre_cmd_next, Pmain_cmd_next = supervisor(Ppre_cmd_next, Pmain_cmd_next, e2, e3)
-
-        # Enforce fixed total-power split between preheater and main heater.
-        # This applies your requested 50/50 split policy.
-        P_total_cmd_next = Ppre_cmd_next + Pmain_cmd_next
-        Ppre_cmd_next = POWER_SPLIT_PRE * P_total_cmd_next
-        Pmain_cmd_next = POWER_SPLIT_MAIN * P_total_cmd_next
+        Ppre_cmd_next, Pmain_cmd_next = allocate_min_power(
+            Ppre_cmd_next,
+            Pmain_cmd_next,
+            e2,
+            e3,
+            losses_pre,
+            losses_main,
+            deadband_K=deadband,
+        )
 
         Ppre_applied_hist[k] = Ppre_applied
         Pmain_applied_hist[k] = Pmain_applied

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -22,9 +22,11 @@ from tqdm import tqdm
 EPS = 1e-30  # tiny number to prevent division-by-zero
 
 # =========================
-# PWM / Duty-cycle actuation (paper-like power spikes)
+# Actuation model
+# - "analog": apply commanded power directly (fine-grained power)
+# - "pwm": binary gate (0 or P_MAX), duty-averaged over time
 # =========================
-PWM_ON = True
+ACTUATION_MODE = "analog"  # "analog" or "pwm"
 PWM_PERIOD = 0.05
 P_MAX_PRE = None
 P_MAX_MAIN = None
@@ -804,14 +806,15 @@ def main():
 
         # Commands computed at time k are applied at k+1 (ZOH).
         t_next = t + FIXED_DT
-        if PWM_ON:
+        if ACTUATION_MODE.lower() == "pwm":
             g_pre = pwm_gate(t_next, d_pre, PWM_PERIOD)
             g_main = pwm_gate(t_next, d_main, PWM_PERIOD)
             Ppre_applied_next = g_pre * _Pmax_pre
             Pmain_applied_next = g_main * _Pmax_main
         else:
-            g_pre = 1.0
-            g_main = 1.0
+            # Analog actuation allows fine power (not only 0 or 20 W).
+            g_pre = d_pre
+            g_main = d_main
             Ppre_applied_next = Ppre_cmd_next
             Pmain_applied_next = Pmain_cmd_next
 
@@ -823,7 +826,7 @@ def main():
                 f"u2_raw(duty)={u2:7.3f} u3_raw(duty)={u3:7.3f} | "
                 f"Ppre_cmd(next)={Ppre_cmd_next:7.3f}W Pmain_cmd(next)={Pmain_cmd_next:7.3f}W | "
                 f"Ppre_applied(now)={Ppre_applied:7.3f}W Pmain_applied(now)={Pmain_applied:7.3f}W | "
-                f"d_pre={d_pre:5.3f} d_main={d_main:5.3f} g_pre(next)={g_pre:3.0f} g_main(next)={g_main:3.0f}"
+                f"d_pre={d_pre:5.3f} d_main={d_main:5.3f} act_pre(next)={g_pre:5.3f} act_main(next)={g_main:5.3f}"
             )
 
         Ppre_applied = Ppre_applied_next

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -25,7 +25,7 @@ EPS = 1e-30  # tiny number to prevent division-by-zero
 # PWM / Duty-cycle actuation (paper-like power spikes)
 # =========================
 PWM_ON = True
-PWM_PERIOD = 0.50
+PWM_PERIOD = 0.05
 P_MAX_PRE = None
 P_MAX_MAIN = None
 
@@ -61,6 +61,7 @@ SUPERVISOR_ON = True
 PRINT_EVERY = 20
 SP_FILTER_TAU = 1.5            # [s] setpoint prefilter time constant
 CMD_RATE_LIMIT_W_PER_S = 4.0   # [W/s] command slew-rate limit
+OVERSHOOT_GUARD_HORIZON_S = 0.25  # [s] predictive cutoff horizon
 
 # =============================================================================
 # DISCRETIZATION / RUNTIME
@@ -387,6 +388,19 @@ class AdaptivePIDNN:
         return float(u)
 
 
+def apply_anticipatory_cutoff(Ppre_cmd, Pmain_cmd, T2, T3, SP2, SP3, dT2_dt, dT3_dt, horizon_s):
+    """Reduce heater commands when projected temperature exceeds filtered setpoint."""
+    T2_proj = T2 + max(dT2_dt, 0.0) * max(horizon_s, 0.0)
+    T3_proj = T3 + max(dT3_dt, 0.0) * max(horizon_s, 0.0)
+
+    if T3_proj >= SP3:
+        Pmain_cmd = 0.0
+    if T2_proj >= SP2:
+        Ppre_cmd = 0.0
+
+    return float(max(Ppre_cmd, 0.0)), float(max(Pmain_cmd, 0.0))
+
+
 # =============================================================================
 # SUPERVISOR
 # =============================================================================
@@ -645,6 +659,10 @@ def main():
         T3 = float(T_fl[rtd3])
         Tw3 = float(T_wall[rtd3])
 
+        prev_idx = max(k - 1, 0)
+        dT2_dt = (T2 - T2_hist[prev_idx]) / FIXED_DT if k > 1 else 0.0
+        dT3_dt = (T3 - T3_hist[prev_idx]) / FIXED_DT if k > 1 else 0.0
+
         T0 = float(T3)
         P0 = float(p[rtd3])
         x_exit_raw = quality_from_hP(float(h[rtd3]), float(p[rtd3]), specie=specie, clip=False)
@@ -727,6 +745,18 @@ def main():
             losses_pre,
             losses_main,
             deadband_K=deadband,
+        )
+
+        Ppre_cmd_next, Pmain_cmd_next = apply_anticipatory_cutoff(
+            Ppre_cmd_next,
+            Pmain_cmd_next,
+            T2,
+            T3,
+            SP2_f,
+            SP3_f,
+            dT2_dt,
+            dT3_dt,
+            OVERSHOOT_GUARD_HORIZON_S,
         )
 
         Ppre_cmd_next = rate_limit(Ppre_cmd_prev, Ppre_cmd_next, CMD_RATE_LIMIT_W_PER_S, FIXED_DT)

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -61,13 +61,14 @@ def rate_limit(prev_cmd, cmd_target, slew_rate_w_per_s, dt):
 # =============================================================================
 FIXED_DT = 0.01
 SUPERVISOR_ON = False
-PRINT_EVERY = 20
+PRINT_EVERY = 100
 SP_FILTER_TAU = 1.5            # [s] setpoint prefilter time constant
 CMD_RATE_LIMIT_W_PER_S = 4.0   # [W/s] command slew-rate limit
 USE_ALLOCATOR = False          # baseline mode: keep PID authority
 USE_ANTICIPATORY_CUTOFF = False
 USE_HARD_CUTOFF = True
 OVERSHOOT_GUARD_HORIZON_S = 0.25  # [s] predictive cutoff horizon
+NOZZLE_DIAGNOSTICS_EVERY = 10  # compute expensive nozzle metrics every N steps (1 = every step)
 PREHEAT_HARD_CUTOFF_K = 0.5  # [K] force preheater OFF above filtered setpoint
 MAIN_HARD_CUTOFF_K = 0.5     # [K] force main heater OFF above filtered setpoint
 
@@ -678,7 +679,12 @@ def main():
         x_exit_raw = quality_from_hP(float(h[rtd3]), float(p[rtd3]), specie=specie, clip=False)
         x_exit_clip = quality_from_hP(float(h[rtd3]), float(p[rtd3]), specie=specie, clip=True)
 
-        m_dot_act, u_e, eta_u = nozzle_metrics(T0, P0, x_exit_clip, specie=specie)
+        if (k % max(NOZZLE_DIAGNOSTICS_EVERY, 1)) == 0 or k == 1:
+            m_dot_act, u_e, eta_u = nozzle_metrics(T0, P0, x_exit_clip, specie=specie)
+        else:
+            m_dot_act = noz_mdot_act[k - 1]
+            u_e = noz_ue[k - 1]
+            eta_u = noz_eta_u[k - 1]
 
         noz_T0[k] = T0
         noz_P0[k] = P0

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -61,7 +61,9 @@ def rate_limit(prev_cmd, cmd_target, slew_rate_w_per_s, dt):
 # =============================================================================
 # USER SWITCHES
 # =============================================================================
-FIXED_DT = 0.01
+FIXED_DT = 0.01  # treated as dt_max in adaptive-CFL stepping
+CFL_TARGET = 0.7
+DT_MIN = 1e-4
 SUPERVISOR_ON = False
 PRINT_EVERY = 100
 SP_FILTER_TAU = 1.5            # [s] setpoint prefilter time constant
@@ -315,6 +317,25 @@ def zone_losses(Tw_zone, A_zone):
         + 0.001 * calculation_P_cond_struct(k_Si, Tw_zone, T_ambient, A_zone, L_ext)
     )
     return float(max(losses, 0.0))
+
+
+def estimate_representative_velocity(h, p, A_cs, mass_flow, specie):
+    """Estimate representative channel velocity for adaptive-CFL dt selection."""
+    vmax = 0.0
+    for i in range(1, len(h)):
+        p_i = float(max(p[i], 1e3))
+        h_i = float(h[i])
+        try:
+            rho_i = float(CP.PropsSI("D", "P", p_i, "H", h_i, specie))
+        except Exception:
+            hL = CP.PropsSI("H", "P", p_i, "Q", 0, specie)
+            hV = CP.PropsSI("H", "P", p_i, "Q", 1, specie)
+            h_eval = float(np.clip(h_i, hL - 8e4, hV + 8e4))
+            rho_i = float(CP.PropsSI("D", "P", p_i, "H", h_eval, specie))
+        v_i = mass_flow / (max(rho_i, EPS) * max(float(A_cs[i]), EPS))
+        if v_i > vmax:
+            vmax = v_i
+    return float(max(vmax, EPS))
 
 
 def robust_temperature_from_ph(p_val, h_val, specie):
@@ -573,7 +594,7 @@ def plant_step_transient(
         p_new[i] = float(max(p_new[i - 1] - dp, 1e3))
 
         x_loc = float(np.clip(quality_from_hP(h_eval, p_i, specie, clip=False), 0.0, 1.0))
-        if x_loc >= X_DRYOUT_ONSET:
+        if 0.0 < x_loc < 1.0 and x_loc >= X_DRYOUT_ONSET:
             dryout_frac = (x_loc - X_DRYOUT_ONSET) / max(1.0 - X_DRYOUT_ONSET, EPS)
             dryout_frac = float(np.clip(dryout_frac, 0.0, 1.0))
             Nu_eff = NU_BASE * (1.0 - DRYOUT_NU_DROP_MAX * dryout_frac)
@@ -613,13 +634,29 @@ def plant_step_transient(
         else:
             T_w[i] = float(T_new)
 
+    pre_zone_mask = slice(1, max(rtd2, 1))
+    main_zone_mask = slice(max(rtd2, 1), max(rtd3, rtd2 + 1))
+    Tref_pre = float(np.mean(T_fl[pre_zone_mask])) if (max(rtd2, 1) - 1) > 0 else float(T_inlet)
+    main_fallback_idx = min(max(rtd2, 1), n - 1)
+    Tref_main = float(np.mean(T_fl[main_zone_mask])) if (max(rtd3, rtd2 + 1) - max(rtd2, 1)) > 0 else float(T_fl[main_fallback_idx])
+
+    pre_available = max(P_pre_net, 0.0) + max(Cw_pre, EPS) * max(Tw_pre_zone - Tref_pre, 0.0) / max(dt_fixed, EPS)
+    main_available = max(P_main_net, 0.0) + max(Cw_main, EPS) * max(Tw_main_zone - Tref_main, 0.0) / max(dt_fixed, EPS)
+
     Tw_pre_next = float(Tw_pre_zone + dt_fixed * (max(P_pre_net, 0.0) - Qdot_f_pre_sum) / max(Cw_pre, EPS))
     Tw_main_next = float(Tw_main_zone + dt_fixed * (max(P_main_net, 0.0) - Qdot_f_main_sum) / max(Cw_main, EPS))
 
     T_fl[0] = T_inlet
     T_w[0] = Tw_pre_next
 
-    return h_new, p_new, T_fl, T_w, Tw_pre_next, Tw_main_next
+    conv_diag = {
+        "pre_qconv": float(Qdot_f_pre_sum),
+        "main_qconv": float(Qdot_f_main_sum),
+        "pre_qavail": float(pre_available),
+        "main_qavail": float(main_available),
+    }
+
+    return h_new, p_new, T_fl, T_w, Tw_pre_next, Tw_main_next, conv_diag
 
 
 # =============================================================================
@@ -698,15 +735,23 @@ def main():
     Isp_act = np.zeros(n_steps)
     Ptot_cmd_before_losses_hist = np.zeros(n_steps)
     Ptot_applied_hist = np.zeros(n_steps)
+    dt_hist = np.zeros(n_steps)
+    conv_overdraw_pre_hist = np.zeros(n_steps)
+    conv_overdraw_main_hist = np.zeros(n_steps)
 
     SP2_f = float(setpoint_rtd2(0.0))
     SP3_f = float(setpoint_rtd3(0.0))
     Ppre_cmd_prev = 0.0
     Pmain_cmd_prev = 0.0
 
+    t = 0.0
     for k in tqdm(range(1, n_steps), desc="Simulating", dynamic_ncols=True):
-        t = k * FIXED_DT
+        v_rep = estimate_representative_velocity(h, p, Acs, mass_flow, specie)
+        dt_step = float(np.clip(CFL_TARGET * dx / (v_rep + EPS), DT_MIN, FIXED_DT))
+
+        t += dt_step
         time[k] = t
+        dt_hist[k] = dt_step
 
         # paper-style net power: subtract losses before thermal update
         losses_pre_now = zone_losses(Tw_pre_zone, A_pre)
@@ -714,7 +759,7 @@ def main():
         Ppre_net_now = max(Ppre_applied - losses_pre_now, 0.0)
         Pmain_net_now = max(Pmain_applied - losses_main_now, 0.0)
 
-        h, p, T_fl, T_wall, Tw_pre_zone, Tw_main_zone = plant_step_transient(
+        h, p, T_fl, T_wall, Tw_pre_zone, Tw_main_zone, conv_diag = plant_step_transient(
             h,
             p,
             xg,
@@ -732,7 +777,7 @@ def main():
             mass_flow,
             Ppre_net_now,
             Pmain_net_now,
-            FIXED_DT,
+            dt_step,
             Tw_pre_zone,
             Tw_main_zone,
             WALL_CAP_PRE_J_PER_K,
@@ -745,8 +790,8 @@ def main():
         Tw3 = float(T_wall[rtd3])
 
         prev_idx = max(k - 1, 0)
-        dT2_dt = (T2 - T2_hist[prev_idx]) / FIXED_DT if k > 1 else 0.0
-        dT3_dt = (T3 - T3_hist[prev_idx]) / FIXED_DT if k > 1 else 0.0
+        dT2_dt = (T2 - T2_hist[prev_idx]) / dt_step if k > 1 else 0.0
+        dT3_dt = (T3 - T3_hist[prev_idx]) / dt_step if k > 1 else 0.0
 
         T0 = float(T3)
         P0 = float(p[rtd3])
@@ -780,8 +825,8 @@ def main():
 
         SP2 = float(setpoint_rtd2(t))
         SP3 = float(setpoint_rtd3(t))
-        SP2_f = low_pass_setpoint(SP2_f, SP2, FIXED_DT, SP_FILTER_TAU)
-        SP3_f = low_pass_setpoint(SP3_f, SP3, FIXED_DT, SP_FILTER_TAU)
+        SP2_f = low_pass_setpoint(SP2_f, SP2, dt_step, SP_FILTER_TAU)
+        SP3_f = low_pass_setpoint(SP3_f, SP3, dt_step, SP_FILTER_TAU)
         SP2_hist[k] = SP2
         SP3_hist[k] = SP3
         SP2_f_hist[k] = SP2_f
@@ -790,8 +835,8 @@ def main():
         e2 = SP2_f - T2
         e3 = SP3_f - T3
 
-        u2 = float(pid2.update(T2, SP2_f, FIXED_DT))
-        u3 = float(pid3.update(T3, SP3_f, FIXED_DT))
+        u2 = float(pid2.update(T2, SP2_f, dt_step))
+        u3 = float(pid3.update(T3, SP3_f, dt_step))
         u2_raw[k] = u2
         u3_raw[k] = u3
 
@@ -802,21 +847,11 @@ def main():
         kp2_hist[k], ki2_hist[k], kd2_hist[k] = pid2.kp, pid2.ki, pid2.kd
         kp3_hist[k], ki3_hist[k], kd3_hist[k] = pid3.kp, pid3.ki, pid3.kd
 
-        Tw_pre = float(np.mean(T_wall[: max(rtd2, 1)]))
-        Tw_main = float(np.mean(T_wall[rtd2 : max(rtd3, rtd2 + 1)]))
+        losses_pre = losses_pre_now
+        losses_main = losses_main_now
 
-        losses_pre = (
-            calculation_P_rad(Tw_pre, T_ambient, em, sigma_stef_boltz, A_pre)
-            + calculation_P_conv(h_conv_ext, Tw_pre, T_ambient, A_pre)
-            + 0.001 * calculation_P_cond_struct(k_Si, Tw_pre, T_ambient, A_pre, L_ext)
-        )
-        losses_main = (
-            calculation_P_rad(Tw_main, T_ambient, em, sigma_stef_boltz, A_main)
-            + calculation_P_conv(h_conv_ext, Tw_main, T_ambient, A_main)
-            + 0.001 * calculation_P_cond_struct(k_Si, Tw_main, T_ambient, A_main, L_ext)
-        )
-        losses_pre = float(max(losses_pre, 0.0))
-        losses_main = float(max(losses_main, 0.0))
+        conv_overdraw_pre_hist[k] = max(0.0, conv_diag["pre_qconv"] - conv_diag["pre_qavail"])
+        conv_overdraw_main_hist[k] = max(0.0, conv_diag["main_qconv"] - conv_diag["main_qavail"])
 
         if e2 > deadband:
             d_pre_cmd_next = float(np.clip(u2, 0.0, 1.0))
@@ -869,8 +904,8 @@ def main():
             if T3 >= (SP3_f + MAIN_HARD_CUTOFF_K):
                 Pmain_cmd_next = 0.0
 
-        Ppre_cmd_next = rate_limit(Ppre_cmd_prev, Ppre_cmd_next, CMD_RATE_LIMIT_W_PER_S, FIXED_DT)
-        Pmain_cmd_next = rate_limit(Pmain_cmd_prev, Pmain_cmd_next, CMD_RATE_LIMIT_W_PER_S, FIXED_DT)
+        Ppre_cmd_next = rate_limit(Ppre_cmd_prev, Ppre_cmd_next, CMD_RATE_LIMIT_W_PER_S, dt_step)
+        Pmain_cmd_next = rate_limit(Pmain_cmd_prev, Pmain_cmd_next, CMD_RATE_LIMIT_W_PER_S, dt_step)
         Ppre_cmd_prev = Ppre_cmd_next
         Pmain_cmd_prev = Pmain_cmd_next
 
@@ -887,7 +922,7 @@ def main():
         d_main = duty_from_power(Pmain_cmd_next, _Pmax_main)
 
         # Commands computed at time k are applied at k+1 (ZOH).
-        t_next = t + FIXED_DT
+        t_next = t + dt_step
         if ACTUATION_MODE.lower() == "pwm":
             g_pre = pwm_gate(t_next, d_pre, PWM_PERIOD)
             g_main = pwm_gate(t_next, d_main, PWM_PERIOD)
@@ -902,7 +937,7 @@ def main():
 
         if PRINT_EVERY and (k % PRINT_EVERY == 0 or k == n_steps - 1):
             print(
-                f"k={k:5d} t={t:8.3f}s dt={FIXED_DT:0.4f}s | "
+                f"k={k:5d} t={t:8.3f}s dt={dt_step:0.4f}s | "
                 f"SP2={SP2:7.2f}K T2_fl={T2:7.2f}K T2_w={Tw2:7.2f}K e2={e2:8.2f} | "
                 f"SP3={SP3:7.2f}K T3_fl={T3:7.2f}K T3_w={Tw3:7.2f}K e3={e3:8.2f} | "
                 f"u2_raw(duty)={u2:7.3f} u3_raw(duty)={u3:7.3f} | "

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -739,6 +739,25 @@ def main():
         Ppre_cmd_next_hist[k] = Ppre_cmd_next
         Pmain_cmd_next_hist[k] = Pmain_cmd_next
 
+        _Pmax_pre = float(q_max) if P_MAX_PRE is None else float(P_MAX_PRE)
+        _Pmax_main = float(q_max) if P_MAX_MAIN is None else float(P_MAX_MAIN)
+
+        d_pre = duty_from_power(Ppre_cmd_next, _Pmax_pre)
+        d_main = duty_from_power(Pmain_cmd_next, _Pmax_main)
+
+        # Commands computed at time k are applied at k+1 (ZOH).
+        t_next = t + FIXED_DT
+        if PWM_ON:
+            g_pre = pwm_gate(t_next, d_pre, PWM_PERIOD)
+            g_main = pwm_gate(t_next, d_main, PWM_PERIOD)
+            Ppre_applied_next = g_pre * _Pmax_pre
+            Pmain_applied_next = g_main * _Pmax_main
+        else:
+            g_pre = 1.0
+            g_main = 1.0
+            Ppre_applied_next = Ppre_cmd_next
+            Pmain_applied_next = Pmain_cmd_next
+
         if PRINT_EVERY and (k % PRINT_EVERY == 0 or k == n_steps - 1):
             print(
                 f"k={k:5d} t={t:8.3f}s dt={FIXED_DT:0.4f}s | "
@@ -746,23 +765,12 @@ def main():
                 f"SP3={SP3:7.2f}K T3_fl={T3:7.2f}K T3_w={Tw3:7.2f}K e3={e3:8.2f} | "
                 f"u2_raw(duty)={u2:7.3f} u3_raw(duty)={u3:7.3f} | "
                 f"Ppre_cmd(next)={Ppre_cmd_next:7.3f}W Pmain_cmd(next)={Pmain_cmd_next:7.3f}W | "
-                f"Ppre_applied(now)={Ppre_applied:7.3f}W Pmain_applied(now)={Pmain_applied:7.3f}W"
+                f"Ppre_applied(now)={Ppre_applied:7.3f}W Pmain_applied(now)={Pmain_applied:7.3f}W | "
+                f"d_pre={d_pre:5.3f} d_main={d_main:5.3f} g_pre(next)={g_pre:3.0f} g_main(next)={g_main:3.0f}"
             )
 
-        _Pmax_pre = float(q_max) if P_MAX_PRE is None else float(P_MAX_PRE)
-        _Pmax_main = float(q_max) if P_MAX_MAIN is None else float(P_MAX_MAIN)
-
-        d_pre = duty_from_power(Ppre_cmd_next, _Pmax_pre)
-        d_main = duty_from_power(Pmain_cmd_next, _Pmax_main)
-
-        if PWM_ON:
-            g_pre = pwm_gate(t, d_pre, PWM_PERIOD)
-            g_main = pwm_gate(t, d_main, PWM_PERIOD)
-            Ppre_applied = g_pre * _Pmax_pre
-            Pmain_applied = g_main * _Pmax_main
-        else:
-            Ppre_applied = Ppre_cmd_next
-            Pmain_applied = Pmain_cmd_next
+        Ppre_applied = Ppre_applied_next
+        Pmain_applied = Pmain_applied_next
 
         d_pre_hist[k] = d_pre
         d_main_hist[k] = d_main

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -79,6 +79,11 @@ MAX_QFLUX_W_M2 = 2.0e6        # cap local imposed heat flux for wall diagnostic 
 MAX_WALL_SUPERHEAT_K = 120.0  # cap (T_wall - T_fluid) diagnostic rise
 WALL_CAP_PRE_J_PER_K = 0.02
 WALL_CAP_MAIN_J_PER_K = 0.03
+# Minimal dryout/regime model (placeholder until CHF correlation is added)
+NU_BASE = 4.96
+X_DRYOUT_ONSET = 0.85
+NU_POST_DRYOUT_MIN = 1.2
+DRYOUT_NU_DROP_MAX = 0.7
 
 # Paper-style neural adaptive PID constraints
 KP_MAX_PAPER = 0.001
@@ -521,12 +526,6 @@ def plant_step_transient(
     p[0] = float(max(p0, 1e3))
     h[0] = float(CP.PropsSI("H", "P", p[0], "T", T_inlet, specie))
 
-    n_pre = max(rtd2, 1)
-    n_main = max(rtd3 - rtd2, 1)
-
-    Ppre_cell = float(max(P_pre_net, 0.0)) / n_pre
-    Pmain_cell = float(max(P_main_net, 0.0)) / n_main
-
     T_fl = np.zeros(n)
     T_w = np.zeros(n)
 
@@ -573,28 +572,29 @@ def plant_step_transient(
         dp = 12.0 * mu_mix * (v / (H_int**2 + EPS)) * dx
         p_new[i] = float(max(p_new[i - 1] - dp, 1e3))
 
-        Nu = 4.96
-        hb = Nu * k_mix / (Dh[i] + EPS)
+        x_loc = float(np.clip(quality_from_hP(h_eval, p_i, specie, clip=False), 0.0, 1.0))
+        if x_loc >= X_DRYOUT_ONSET:
+            dryout_frac = (x_loc - X_DRYOUT_ONSET) / max(1.0 - X_DRYOUT_ONSET, EPS)
+            dryout_frac = float(np.clip(dryout_frac, 0.0, 1.0))
+            Nu_eff = NU_BASE * (1.0 - DRYOUT_NU_DROP_MAX * dryout_frac)
+            Nu_eff = float(max(NU_POST_DRYOUT_MIN, Nu_eff))
+        else:
+            Nu_eff = NU_BASE
+
+        hb = Nu_eff * k_mix / (Dh[i] + EPS)
 
         if i < rtd2:
             Tw_loc = float(Tw_pre_zone)
-            A_ex_i = float(Perim[i] * dx)
-            Pcell = Ppre_cell
             zone = "pre"
         elif i < rtd3:
             Tw_loc = float(Tw_main_zone)
-            A_ex_i = float(W_int[i] * dx)
-            Pcell = Pmain_cell
             zone = "main"
         else:
             Tw_loc = float(T_i)
-            A_ex_i = float(W_int[i] * dx)
-            Pcell = 0.0
             zone = "none"
 
+        A_ex_i = float(Perim[i] * dx)
         Qdot_f_i = max(0.0, hb * (Tw_loc - float(T_i)) * A_ex_i)
-        # steady marching contribution from zone net power in that cell
-        Qdot_f_i += Pcell
 
         if zone == "pre":
             Qdot_f_pre_sum += Qdot_f_i

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -49,8 +49,11 @@ def low_pass_setpoint(prev_sp, target_sp, dt, tau_s):
 
 
 def rate_limit(prev_cmd, cmd_target, slew_rate_w_per_s, dt):
+    """Rate-limit command increase, but allow immediate decreases for safety."""
+    if cmd_target <= prev_cmd:
+        return float(max(cmd_target, 0.0))
     delta_max = max(slew_rate_w_per_s, 0.0) * max(dt, 0.0)
-    return float(np.clip(cmd_target, prev_cmd - delta_max, prev_cmd + delta_max))
+    return float(min(cmd_target, prev_cmd + delta_max))
 
 
 # =============================================================================
@@ -62,6 +65,8 @@ PRINT_EVERY = 20
 SP_FILTER_TAU = 1.5            # [s] setpoint prefilter time constant
 CMD_RATE_LIMIT_W_PER_S = 4.0   # [W/s] command slew-rate limit
 OVERSHOOT_GUARD_HORIZON_S = 0.25  # [s] predictive cutoff horizon
+PREHEAT_HARD_CUTOFF_K = 0.5  # [K] force preheater OFF above filtered setpoint
+MAIN_HARD_CUTOFF_K = 0.5     # [K] force main heater OFF above filtered setpoint
 
 # =============================================================================
 # DISCRETIZATION / RUNTIME
@@ -758,6 +763,12 @@ def main():
             dT3_dt,
             OVERSHOOT_GUARD_HORIZON_S,
         )
+
+        # Hard thermal safety cutoff: never keep heating when node is above filtered target.
+        if T2 >= (SP2_f + PREHEAT_HARD_CUTOFF_K):
+            Ppre_cmd_next = 0.0
+        if T3 >= (SP3_f + MAIN_HARD_CUTOFF_K):
+            Pmain_cmd_next = 0.0
 
         Ppre_cmd_next = rate_limit(Ppre_cmd_prev, Ppre_cmd_next, CMD_RATE_LIMIT_W_PER_S, FIXED_DT)
         Pmain_cmd_next = rate_limit(Pmain_cmd_prev, Pmain_cmd_next, CMD_RATE_LIMIT_W_PER_S, FIXED_DT)

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -78,6 +78,14 @@ MIN_HC_W_M2K = 250.0          # lower bound for internal h to avoid q''/h blow-u
 MAX_QFLUX_W_M2 = 2.0e6        # cap local imposed heat flux for wall diagnostic stability
 MAX_WALL_SUPERHEAT_K = 120.0  # cap (T_wall - T_fluid) diagnostic rise
 
+# Paper-style neural adaptive PID constraints
+KP_MAX_PAPER = 0.001
+KI_MAX_PAPER = 0.01
+KD_MAX_PAPER = 0.0001
+NN_LEARNING_RATE = 0.5
+NN_INIT_STD = 0.005
+
+
 # =============================================================================
 # DISCRETIZATION / RUNTIME
 # =============================================================================
@@ -334,72 +342,79 @@ def setpoint_rtd3(t):
 
 
 # =============================================================================
-# ERROR-BASED ADAPTIVE PID
+# NEURAL ADAPTIVE PID (paper-style constraints)
 # =============================================================================
-class AdaptivePIDErrorBased:
+class AdaptivePIDNeural:
     def __init__(
         self,
-        kp0=0.0005,
-        ki0=0.005,
-        kd0=0.0001,
-        adapt_rate_p=0.1,
-        adapt_rate_i=0.1,
-        adapt_rate_d=0.05,
-        big_error_threshold=5.0,
+        kp_max=KP_MAX_PAPER,
+        ki_max=KI_MAX_PAPER,
+        kd_max=KD_MAX_PAPER,
+        learning_rate=NN_LEARNING_RATE,
+        init_std=NN_INIT_STD,
         integral_clip=1e6,
         u_max=1.0,
+        seed=42,
     ):
-        self.kp0 = kp0
-        self.ki0 = ki0
-        self.kd0 = kd0
-        self.kp = kp0
-        self.ki = ki0
-        self.kd = kd0
-        self.adapt_rate_p = adapt_rate_p
-        self.adapt_rate_i = adapt_rate_i
-        self.adapt_rate_d = adapt_rate_d
-        self.big_error_threshold = big_error_threshold
+        self.kp_max = float(kp_max)
+        self.ki_max = float(ki_max)
+        self.kd_max = float(kd_max)
+        self.learning_rate = float(learning_rate)
         self.u_max = u_max
         self.integral = 0.0
         self.last_error = 0.0
         self.integral_clip = float(integral_clip)
 
+        rng = np.random.default_rng(seed)
+        # Inputs: [error, derivative]
+        self.W = rng.normal(0.0, float(init_std), size=(3, 2))
+        self.b = np.zeros(3)
+
+        self.kp = 0.0
+        self.ki = 0.0
+        self.kd = 0.0
+
+    @staticmethod
+    def _sigmoid(x):
+        return 1.0 / (1.0 + np.exp(-np.clip(x, -60.0, 60.0)))
+
     def update(self, current_value, setpoint, dt):
         error = setpoint - current_value
+        derivative = (error - self.last_error) / dt if dt > 0.0 else 0.0
 
-        # Heating-only integration policy from the December script:
-        # accumulate when below setpoint, quickly decay when above.
-        if error > 0.0:
-            self.integral += error * dt
-        else:
-            self.integral *= max(0.0, 1.0 - 5.0 * dt)
+        self.integral += error * dt
         self.integral = float(np.clip(self.integral, -self.integral_clip, self.integral_clip))
 
-        derivative = (error - self.last_error) / dt if dt > 0.0 else 0.0
-        u = (self.kp * error) + (self.ki * self.integral) + (self.kd * derivative)
+        # normalized NN inputs to stabilize online learning
+        x = np.array([error / 100.0, derivative / 2000.0], dtype=float)
 
-        # Heating actuator cannot command negative duty.
+        z = self.W @ x + self.b
+        g = self._sigmoid(z)
+
+        # Paper constraints: 0 <= K <= K_max
+        self.kp = float(np.clip(self.kp_max * g[0], 0.0, self.kp_max))
+        self.ki = float(np.clip(self.ki_max * g[1], 0.0, self.ki_max))
+        self.kd = float(np.clip(self.kd_max * g[2], 0.0, self.kd_max))
+
+        u = (self.kp * error) + (self.ki * self.integral) + (self.kd * derivative)
         u = max(u, 0.0)
         if self.u_max is not None:
             u = min(u, self.u_max)
 
-        abs_e = abs(error)
-        abs_last_e = abs(self.last_error)
-        big_err = self.big_error_threshold
+        # gradient-based online update (surrogate objective):
+        # minimize J = 0.5*e^2 + 0.01*u^2
+        # dJ/du surrogate couples tracking and power economy
+        dJ_du = -np.tanh(error / 50.0) + 0.01 * u
+        du_dg = np.array([error, self.integral, derivative], dtype=float)
+        gain_scale = np.array([self.kp_max, self.ki_max, self.kd_max], dtype=float)
+        dsig_dz = g * (1.0 - g)
 
-        if (error > 0.0) and (abs_e > big_err) and (abs_e >= abs_last_e):
-            self.kp *= 1.0 + self.adapt_rate_p * dt
-            self.ki *= 1.0 + self.adapt_rate_i * dt
+        dJ_dz = dJ_du * du_dg * gain_scale * dsig_dz
 
-        overshoot = (error < 0.0) and (abs_e > 0.5)
-        if overshoot and abs_last_e > big_err:
-            self.kp *= 1.0 - self.adapt_rate_p * dt
-            self.ki *= 1.0 - self.adapt_rate_i * dt
-            self.kd *= 1.0 + self.adapt_rate_d * dt
-
-        self.kp = float(np.clip(self.kp, 0.2 * self.kp0, 5.0 * self.kp0))
-        self.ki = float(np.clip(self.ki, 0.2 * self.ki0, 5.0 * self.ki0))
-        self.kd = float(np.clip(self.kd, 0.2 * self.kd0, 5.0 * self.kd0))
+        # paper-style learning rate applied in real-time update
+        lr = self.learning_rate
+        self.W += (-lr) * np.outer(dJ_dz, x)
+        self.b += (-lr) * dJ_dz
 
         self.last_error = error
         return float(u)
@@ -603,8 +618,8 @@ def main():
     A_pre = A_ext * frac_pre
     A_main = A_ext * frac_main
 
-    pid2 = AdaptivePIDErrorBased(u_max=1.0)
-    pid3 = AdaptivePIDErrorBased(u_max=1.0)
+    pid2 = AdaptivePIDNeural(u_max=1.0)
+    pid3 = AdaptivePIDNeural(u_max=1.0)
 
     Ppre_applied = 0.0
     Pmain_applied = 0.0

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -81,13 +81,8 @@ MAX_QFLUX_W_M2 = 2.0e6        # cap local imposed heat flux for wall diagnostic 
 MAX_WALL_SUPERHEAT_K = 120.0  # cap (T_wall - T_fluid) diagnostic rise
 WALL_CAP_PRE_J_PER_K = 0.02
 WALL_CAP_MAIN_J_PER_K = 0.03
-# CHF / dryout correlation controls
+# PID-paper transient pathway: constant internal Nu (no CHF/dryout correlation)
 NU_BASE = 4.96
-NU_POST_DRYOUT_MIN = 1.2
-XDO_MIN = 0.55
-XDO_MAX = 0.98
-CHF_C0 = 0.131  # Kutateladze-style prefactor
-CHF_SAFETY_FACTOR = 0.90
 
 # Paper-style neural adaptive PID constraints
 KP_MAX_PAPER = 0.001
@@ -171,48 +166,6 @@ def quality_from_hP(h_val, p_val, specie="Water", clip=True):
     if clip:
         x = np.clip(x, 0.0, 1.0)
     return float(x)
-
-
-def compute_chf_dryout_state(x_loc, G, Dh_i, rho_l, rho_v, mu_l, h_fg, sigma, q_flux_dem):
-    """Correlation-based dryout/CHF model for microchannel two-phase flow.
-
-    Returns:
-        x_do: dryout-onset quality from combined correlations
-        q_chf: local CHF estimate [W/m^2]
-        q_flux_lim: capped convective heat flux [W/m^2]
-        Nu_eff_scale: multiplicative factor applied to nominal Nu
-        regime: string label
-    """
-    # Dimensionless groups
-    Bo = float(np.clip(q_flux_dem / (max(G, EPS) * max(h_fg, EPS)), 1e-8, 1.0))
-    We_lo = float(np.clip((G**2) * max(Dh_i, EPS) / (max(rho_l, EPS) * max(sigma, EPS)), 1e-8, 1e8))
-    La = float(np.clip(max(sigma, EPS) * max(rho_l - rho_v, EPS) * max(Dh_i, EPS) / (max(rho_v, EPS) * (max(mu_l, EPS)**2)), 1e-6, 1e10))
-
-    # Dryout-onset quality correlations (bounded, blended by minimum for conservative prediction)
-    x_incip = float(np.clip(0.99 - 2.25 * (Bo ** 0.35), XDO_MIN, XDO_MAX))
-    x_crit = float(np.clip(0.88 - 0.08 * (We_lo ** -0.10), XDO_MIN, XDO_MAX))
-    x_dry_max = float(np.clip(0.96 - 0.04 * (La ** -0.05), XDO_MIN, XDO_MAX))
-    x_do = float(np.clip(min(x_incip, x_crit, x_dry_max), XDO_MIN, XDO_MAX))
-
-    # Kutateladze-like CHF estimate with two-phase velocity boost
-    q_chf = CHF_C0 * h_fg * math.sqrt(max(rho_v, EPS)) * (max(sigma, EPS) * g0 * max(rho_l - rho_v, EPS)) ** 0.25
-    two_phase_boost = float(np.clip((1.0 + 2.0 * We_lo ** 0.20), 1.0, 6.0))
-    q_chf *= two_phase_boost * CHF_SAFETY_FACTOR
-
-    if not (0.0 < x_loc < 1.0):
-        return x_do, q_chf, q_flux_dem, 1.0, "single_phase"
-
-    if x_loc < x_do:
-        q_flux_lim = min(q_flux_dem, q_chf)
-        return x_do, q_chf, q_flux_lim, 1.0, "nucleate_boiling"
-
-    # Post-dryout: degrade transfer with quality and CHF exceedance
-    dryout_frac = float(np.clip((x_loc - x_do) / max(1.0 - x_do, EPS), 0.0, 1.0))
-    chf_ratio = float(np.clip(q_flux_dem / max(q_chf, EPS), 0.0, 5.0))
-    nu_scale = float(np.clip((1.0 - 0.80 * dryout_frac) * (1.0 / (1.0 + 0.35 * max(chf_ratio - 1.0, 0.0))),
-                             NU_POST_DRYOUT_MIN / max(NU_BASE, EPS), 1.0))
-    q_flux_lim = min(q_flux_dem, q_chf)
-    return x_do, q_chf, q_flux_lim, nu_scale, "post_dryout"
 
 
 def nozzle_metrics(T0, P0, x_vap, specie="Water"):
@@ -599,8 +552,6 @@ def plant_step_transient(
 
     Qdot_f_pre_sum = 0.0
     Qdot_f_main_sum = 0.0
-    chf_limited_cells = 0
-    post_dryout_cells = 0
 
     for i in range(1, n):
         p_i = float(max(p[i], 1e3))
@@ -639,30 +590,6 @@ def plant_step_transient(
         dp = 12.0 * mu_mix * (v / (H_int**2 + EPS)) * dx
         p_new[i] = float(max(p_new[i - 1] - dp, 1e3))
 
-        x_loc = float(np.clip(quality_from_hP(h_eval, p_i, specie, clip=False), 0.0, 1.0))
-        rhoL_loc = CP.PropsSI("D", "P", p_i, "Q", 0, specie)
-        rhoV_loc = CP.PropsSI("D", "P", p_i, "Q", 1, specie)
-        hfg_loc = CP.PropsSI("H", "P", p_i, "Q", 1, specie) - CP.PropsSI("H", "P", p_i, "Q", 0, specie)
-        sigma_loc = CP.PropsSI("I", "P", p_i, "Q", 0, specie)
-        G_loc = mass_flow / (A_flow + EPS)
-
-        hb_nom = NU_BASE * k_mix / (Dh[i] + EPS)
-
-        q_flux_dem = max(0.0, hb_nom * (float((Tw_pre_zone if i < rtd2 else Tw_main_zone) if i < rtd3 else T_i) - float(T_i)))
-        x_do, q_chf, q_flux_lim, nu_scale, regime = compute_chf_dryout_state(
-            x_loc=x_loc,
-            G=G_loc,
-            Dh_i=float(Dh[i]),
-            rho_l=float(rhoL_loc),
-            rho_v=float(rhoV_loc),
-            mu_l=float(muL),
-            h_fg=float(max(hfg_loc, EPS)),
-            sigma=float(max(sigma_loc, EPS)),
-            q_flux_dem=float(q_flux_dem),
-        )
-        Nu_eff = max(NU_POST_DRYOUT_MIN, NU_BASE * nu_scale)
-        hb = Nu_eff * k_mix / (Dh[i] + EPS)
-
         if i < rtd2:
             Tw_loc = float(Tw_pre_zone)
             zone = "pre"
@@ -673,15 +600,12 @@ def plant_step_transient(
             Tw_loc = float(T_i)
             zone = "none"
 
-        A_ex_i = float(Perim[i] * dx)
-        Qdot_nom_i = max(0.0, hb * (Tw_loc - float(T_i)) * A_ex_i)
-        Qdot_chf_cap_i = max(0.0, q_chf * A_ex_i)
-        Qdot_f_i = min(Qdot_nom_i, Qdot_chf_cap_i)
+        hb_nom = NU_BASE * k_mix / (Dh[i] + EPS)
+        q_flux_dem = max(0.0, hb_nom * (Tw_loc - float(T_i)))
 
-        if regime == "post_dryout":
-            post_dryout_cells += 1
-        if Qdot_f_i + 1e-12 < Qdot_nom_i:
-            chf_limited_cells += 1
+        hb = hb_nom
+        A_ex_i = float(Perim[i] * dx)
+        Qdot_f_i = q_flux_dem * A_ex_i
 
         if zone == "pre":
             Qdot_f_pre_sum += Qdot_f_i
@@ -720,8 +644,6 @@ def plant_step_transient(
         "main_qconv": float(Qdot_f_main_sum),
         "pre_qavail": float(pre_available),
         "main_qavail": float(main_available),
-        "chf_limited_cells": int(chf_limited_cells),
-        "post_dryout_cells": int(post_dryout_cells),
     }
 
     return h_new, p_new, T_fl, T_w, Tw_pre_next, Tw_main_next, conv_diag
@@ -806,8 +728,6 @@ def main():
     dt_hist = np.zeros(n_steps)
     conv_overdraw_pre_hist = np.zeros(n_steps)
     conv_overdraw_main_hist = np.zeros(n_steps)
-    chf_limited_cells_hist = np.zeros(n_steps)
-    post_dryout_cells_hist = np.zeros(n_steps)
 
     SP2_f = float(setpoint_rtd2(0.0))
     SP3_f = float(setpoint_rtd3(0.0))
@@ -922,8 +842,6 @@ def main():
 
         conv_overdraw_pre_hist[k] = max(0.0, conv_diag["pre_qconv"] - conv_diag["pre_qavail"])
         conv_overdraw_main_hist[k] = max(0.0, conv_diag["main_qconv"] - conv_diag["main_qavail"])
-        chf_limited_cells_hist[k] = conv_diag["chf_limited_cells"]
-        post_dryout_cells_hist[k] = conv_diag["post_dryout_cells"]
 
         if e2 > deadband:
             d_pre_cmd_next = float(np.clip(u2, 0.0, 1.0))

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -77,6 +77,8 @@ MAIN_HARD_CUTOFF_K = 0.5     # [K] force main heater OFF above filtered setpoint
 MIN_HC_W_M2K = 250.0          # lower bound for internal h to avoid q''/h blow-ups
 MAX_QFLUX_W_M2 = 2.0e6        # cap local imposed heat flux for wall diagnostic stability
 MAX_WALL_SUPERHEAT_K = 120.0  # cap (T_wall - T_fluid) diagnostic rise
+WALL_CAP_PRE_J_PER_K = 0.02
+WALL_CAP_MAIN_J_PER_K = 0.03
 
 # Paper-style neural adaptive PID constraints
 KP_MAX_PAPER = 0.001
@@ -301,6 +303,15 @@ def calculation_P_conv(h_conv, T_wall, T_amb, A_ext_local):
     return h_conv * A_ext_local * (T_wall - T_amb)
 
 
+def zone_losses(Tw_zone, A_zone):
+    losses = (
+        calculation_P_rad(Tw_zone, T_ambient, em, sigma_stef_boltz, A_zone)
+        + calculation_P_conv(h_conv_ext, Tw_zone, T_ambient, A_zone)
+        + 0.001 * calculation_P_cond_struct(k_Si, Tw_zone, T_ambient, A_zone, L_ext)
+    )
+    return float(max(losses, 0.0))
+
+
 def robust_temperature_from_ph(p_val, h_val, specie):
     """Return temperature from (p,h) with minimal state distortion on fallback."""
     p_use = float(max(p_val, 1e3))
@@ -495,9 +506,13 @@ def plant_step_transient(
     L_int,
     dx,
     mass_flow,
-    P_pre,
-    P_main,
+    P_pre_net,
+    P_main_net,
     dt_fixed,
+    Tw_pre_zone,
+    Tw_main_zone,
+    Cw_pre,
+    Cw_main,
 ):
     n = len(h)
     rtd2 = find_nearest_index(x, L_inlet + L_uCh)
@@ -509,14 +524,8 @@ def plant_step_transient(
     n_pre = max(rtd2, 1)
     n_main = max(rtd3 - rtd2, 1)
 
-    Q = np.zeros(n)
-    for i in range(n):
-        if i < rtd2:
-            Q[i] = P_pre / n_pre
-        elif i < rtd3:
-            Q[i] = P_main / n_main
-        else:
-            Q[i] = 0.0
+    Ppre_cell = float(max(P_pre_net, 0.0)) / n_pre
+    Pmain_cell = float(max(P_main_net, 0.0)) / n_main
 
     T_fl = np.zeros(n)
     T_w = np.zeros(n)
@@ -524,13 +533,14 @@ def plant_step_transient(
     h_new = h.copy()
     p_new = p.copy()
 
+    Qdot_f_pre_sum = 0.0
+    Qdot_f_main_sum = 0.0
+
     for i in range(1, n):
         p_i = float(max(p[i], 1e3))
 
         T_i = robust_temperature_from_ph(p_i, h[i], specie)
 
-        # Use a bounded local enthalpy only for property evaluation; do not
-        # overwrite the transported state directly to avoid artificial plateaus.
         hL_loc = CP.PropsSI("H", "P", p_i, "Q", 0, specie)
         hV_loc = CP.PropsSI("H", "P", p_i, "Q", 1, specie)
         h_eval = float(np.clip(h[i], hL_loc - 8e4, hV_loc + 8e4))
@@ -560,35 +570,56 @@ def plant_step_transient(
         v = mass_flow / (rho * A_flow + EPS)
         CFL = float(np.clip(v * dt_fixed / (dx + EPS), 0.0, 1.0))
 
-        dh_src = CFL * (Q[i] / (mass_flow + EPS))
-        h_new[i] = h[i] - CFL * (h[i] - h[i - 1]) + dh_src
-
         dp = 12.0 * mu_mix * (v / (H_int**2 + EPS)) * dx
         p_new[i] = float(max(p_new[i - 1] - dp, 1e3))
 
         Nu = 4.96
-        hc_raw = Nu * k_mix / (Dh[i] + EPS)
-        hc_eff = max(hc_raw, MIN_HC_W_M2K)
+        hb = Nu * k_mix / (Dh[i] + EPS)
 
         if i < rtd2:
-            qflux = Q[i] / (Perim[i] * dx + EPS)
+            Tw_loc = float(Tw_pre_zone)
+            A_ex_i = float(Perim[i] * dx)
+            Pcell = Ppre_cell
+            zone = "pre"
         elif i < rtd3:
-            qflux = Q[i] / (W_int[i] * dx + EPS)
+            Tw_loc = float(Tw_main_zone)
+            A_ex_i = float(W_int[i] * dx)
+            Pcell = Pmain_cell
+            zone = "main"
         else:
-            qflux = 0.0
-        qflux = float(np.clip(qflux, 0.0, MAX_QFLUX_W_M2))
+            Tw_loc = float(T_i)
+            A_ex_i = float(W_int[i] * dx)
+            Pcell = 0.0
+            zone = "none"
+
+        Qdot_f_i = max(0.0, hb * (Tw_loc - float(T_i)) * A_ex_i)
+        # steady marching contribution from zone net power in that cell
+        Qdot_f_i += Pcell
+
+        if zone == "pre":
+            Qdot_f_pre_sum += Qdot_f_i
+        elif zone == "main":
+            Qdot_f_main_sum += Qdot_f_i
+
+        dh_src = Qdot_f_i * dt_fixed / (mass_flow + EPS)
+        h_new[i] = h[i] - CFL * (h[i] - h[i - 1]) + dh_src
 
         T_new = robust_temperature_from_ph(p_new[i], h_new[i], specie)
-
         T_fl[i] = float(T_new)
-        dT_wall = qflux / (hc_eff + EPS)
-        dT_wall = float(np.clip(dT_wall, 0.0, MAX_WALL_SUPERHEAT_K))
-        T_w[i] = float(T_new) + dT_wall
+        if zone == "pre":
+            T_w[i] = float(Tw_pre_zone)
+        elif zone == "main":
+            T_w[i] = float(Tw_main_zone)
+        else:
+            T_w[i] = float(T_new)
+
+    Tw_pre_next = float(Tw_pre_zone + dt_fixed * (max(P_pre_net, 0.0) - Qdot_f_pre_sum) / max(Cw_pre, EPS))
+    Tw_main_next = float(Tw_main_zone + dt_fixed * (max(P_main_net, 0.0) - Qdot_f_main_sum) / max(Cw_main, EPS))
 
     T_fl[0] = T_inlet
-    T_w[0] = T_inlet
+    T_w[0] = Tw_pre_next
 
-    return h_new, p_new, T_fl, T_w
+    return h_new, p_new, T_fl, T_w, Tw_pre_next, Tw_main_next
 
 
 # =============================================================================
@@ -623,6 +654,8 @@ def main():
 
     Ppre_applied = 0.0
     Pmain_applied = 0.0
+    Tw_pre_zone = float(T_wall_start)
+    Tw_main_zone = float(T_wall_start)
 
     h0 = float(CP.PropsSI("H", "P", p_start, "T", T_fl_start, specie))
     h = np.ones(n_it) * h0
@@ -675,7 +708,13 @@ def main():
         t = k * FIXED_DT
         time[k] = t
 
-        h, p, T_fl, T_wall = plant_step_transient(
+        # paper-style net power: subtract losses before thermal update
+        losses_pre_now = zone_losses(Tw_pre_zone, A_pre)
+        losses_main_now = zone_losses(Tw_main_zone, A_main)
+        Ppre_net_now = max(Ppre_applied - losses_pre_now, 0.0)
+        Pmain_net_now = max(Pmain_applied - losses_main_now, 0.0)
+
+        h, p, T_fl, T_wall, Tw_pre_zone, Tw_main_zone = plant_step_transient(
             h,
             p,
             xg,
@@ -691,9 +730,13 @@ def main():
             L_int,
             dx,
             mass_flow,
-            Ppre_applied,
-            Pmain_applied,
+            Ppre_net_now,
+            Pmain_net_now,
             FIXED_DT,
+            Tw_pre_zone,
+            Tw_main_zone,
+            WALL_CAP_PRE_J_PER_K,
+            WALL_CAP_MAIN_J_PER_K,
         )
 
         T2 = float(T_fl[rtd2])

--- a/heater_dual_pid_fixed.py
+++ b/heater_dual_pid_fixed.py
@@ -277,6 +277,19 @@ def calculation_P_conv(h_conv, T_wall, T_amb, A_ext_local):
     return h_conv * A_ext_local * (T_wall - T_amb)
 
 
+def robust_temperature_from_ph(p_val, h_val, specie):
+    """Return temperature from (p,h) with minimal state distortion on fallback."""
+    p_use = float(max(p_val, 1e3))
+    try:
+        return float(CP.PropsSI("T", "P", p_use, "H", h_val, specie))
+    except Exception:
+        hL = CP.PropsSI("H", "P", p_use, "Q", 0, specie)
+        hV = CP.PropsSI("H", "P", p_use, "Q", 1, specie)
+        # Narrow fallback band to reduce state pinning/plateau artifacts.
+        h_eval = float(np.clip(h_val, hL - 8e4, hV + 8e4))
+        return float(CP.PropsSI("T", "P", p_use, "H", h_eval, specie))
+
+
 # =============================================================================
 # SETPOINTS — Option B (stepwise)
 # =============================================================================
@@ -468,17 +481,16 @@ def plant_step_transient(
     for i in range(1, n):
         p_i = float(max(p[i], 1e3))
 
-        try:
-            T_i = CP.PropsSI("T", "P", p_i, "H", h[i], specie)
-        except Exception:
-            hL = CP.PropsSI("H", "P", p_i, "Q", 0, specie)
-            hV = CP.PropsSI("H", "P", p_i, "Q", 1, specie)
-            h[i] = float(np.clip(h[i], hL - 2e5, hV + 2e5))
-            T_i = CP.PropsSI("T", "P", p_i, "H", h[i], specie)
+        T_i = robust_temperature_from_ph(p_i, h[i], specie)
 
-        rho = CP.PropsSI("D", "P", p_i, "H", h[i], specie)
+        # Use a bounded local enthalpy only for property evaluation; do not
+        # overwrite the transported state directly to avoid artificial plateaus.
+        hL_loc = CP.PropsSI("H", "P", p_i, "Q", 0, specie)
+        hV_loc = CP.PropsSI("H", "P", p_i, "Q", 1, specie)
+        h_eval = float(np.clip(h[i], hL_loc - 8e4, hV_loc + 8e4))
+        rho = CP.PropsSI("D", "P", p_i, "H", h_eval, specie)
 
-        phase = CP.PhaseSI("P", p_i, "HMASS", h[i], specie)
+        phase = CP.PhaseSI("P", p_i, "HMASS", h_eval, specie)
         phase_l = phase.lower()
         if "liquid" in phase_l and "twophase" not in phase_l:
             x_v = 0.0
@@ -518,14 +530,7 @@ def plant_step_transient(
         else:
             qflux = 0.0
 
-        try:
-            T_new = CP.PropsSI("T", "P", p_new[i], "H", h_new[i], specie)
-        except Exception:
-            p_tmp = float(max(p_new[i], 1e3))
-            hL2 = CP.PropsSI("H", "P", p_tmp, "Q", 0, specie)
-            hV2 = CP.PropsSI("H", "P", p_tmp, "Q", 1, specie)
-            h_new[i] = float(np.clip(h_new[i], hL2 - 2e5, hV2 + 2e5))
-            T_new = CP.PropsSI("T", "P", p_tmp, "H", h_new[i], specie)
+        T_new = robust_temperature_from_ph(p_new[i], h_new[i], specie)
 
         T_fl[i] = float(T_new)
         T_w[i] = qflux / (hc + EPS) + float(T_new)


### PR DESCRIPTION
### Motivation
- Provide the same 3-panel diagnostic figure for both heaters so RTD2 and RTD3 have matching temperature, heat-input and PID-parameter panels as requested.
- Capture adaptive PID gains over time to allow inspection of controller adaptation for each heater.

### Description
- Updated `heater_dual_pid_fixed.py` to record per-loop adaptive PID gain histories with new arrays `kp2_hist`, `ki2_hist`, `kd2_hist`, `kp3_hist`, `ki3_hist`, and `kd3_hist` that are populated each simulation step.
- Replaced the previous separate 2-panel plotting blocks with a reusable `plot_heater_panel(...)` routine that creates a 3-panel figure for a given heater showing temperature, heat input (with total heat and average power annotation), and PID parameters.
- Applied `plot_heater_panel(...)` to both `RTD2` and `RTD3` so both heaters produce matching 3-panel plots while leaving the existing nozzle diagnostics figure unchanged.

### Testing
- Performed static syntax validation with `python -m py_compile heater_dual_pid_fixed.py`, which completed successfully.
- The modified script was inspected and the new plotting routine and PID-history writes were verified to be present and syntactically correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c3cb86fe083338d9797566e8cd997)